### PR TITLE
Dark Angels - Update Shared Rules for 7th Edition BRB.

### DIFF
--- a/Dark Angels - Codex.cat
+++ b/Dark Angels - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="49ec5c4a-e83d-298f-9f4d-27c1fa888842" revision="35" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Dark Angels: Codex (2013) v34" authorName="LM" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="49ec5c4a-e83d-298f-9f4d-27c1fa888842" revision="36" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Dark Angels: Codex (2013) v36" authorName="LM" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="6678c325-2a8f-1dec-473f-7b94d3d9a924" name="[FW] Contemptor Mortis Dreadnought" points="155.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="Imperial Armour - Aeronautica" page="1">
       <entries>
@@ -822,23 +822,6 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="db1c682b-4c0c-2b0f-46e8-3cc00646c651" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="344b3905-e7b0-c676-aedc-bd4473631ea4" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="36697358-df2c-d1ca-57c9-cd743528a0bc" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="b62648b8-c072-c08f-85f2-16b1d658d986" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
           <entries/>
           <entryGroups/>
@@ -865,33 +848,6 @@
           <description>+1 Victory point if your Warlord or his unit kill enemy Warlord in the Assault phase.</description>
           <modifiers/>
         </rule>
-        <rule id="686898c5-9220-0018-4360-d50516ffeacd" name="Fear" hidden="false" book="BRB" page="35">
-          <description>At the start of the Fight sub-phase, a unit in base contact with this model must take a Fear test.
-
-If the test is failed then the unit has it&apos;s WS reduced to 1 for the remainder of the phase.
-
-Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are immune to this rule.</description>
-          <modifiers/>
-        </rule>
-        <rule id="f71fccd5-b112-0a81-3edb-6d8dca18717c" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
-        <rule id="0ac04510-2773-8dbc-55f0-1170a2a876f9" name="Zealot" hidden="false" book="BRB" page="43">
-          <description>Unit this Character is joined to has Fearless and Hatred (Everything)</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles>
         <profile id="ede42018-8bf9-ff13-6e73-2daf47f57b4b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Asmodai" hidden="false" book="Codex: Dark Angels 6th" page="55">
@@ -910,7 +866,20 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="e12d9b85-f11f-4574-444b-725a514f54a8" targetId="ca219793-6e3f-63f3-e811-6b9920eec96a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="946d49ee-2044-4fc7-582c-527698d57341" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c66f06ce-b8f7-6762-533a-70c28f81eca2" targetId="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ca65c947-1225-2c81-f95d-1965055cdf31" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="f0b134e6-02c6-60bd-b96b-d97c18c31833" name="Assault Squad" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="35">
       <entries>
@@ -1019,7 +988,7 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
             <entryGroup id="6997c819-0780-c104-8d33-3e7ed45f8679" name="Sergeant Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
               <entries/>
               <entryGroups>
-                <entryGroup id="7ec7303f-b60e-1f1a-097f-16a55cf5f7e4" name="Right Hand" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
+                <entryGroup id="7ec7303f-b60e-1f1a-097f-16a55cf5f7e4" name="Right Hand" defaultEntryId="313cb93f-d747-9f12-ba85-a0cde4e68e84" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
                   <entries>
                     <entry id="667755eb-180f-26d0-92b1-6c49e5615df1" name="Storm Bolter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
                       <entries/>
@@ -1278,7 +1247,7 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="3366d574-13b6-54e8-fe80-96b6979d8d38" name="Left Hand" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
+                <entryGroup id="3366d574-13b6-54e8-fe80-96b6979d8d38" name="Left Hand" defaultEntryId="da5f8063-1cef-222b-a50a-dfd4c1952476" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
                   <entries>
                     <entry id="da5f8063-1cef-222b-a50a-dfd4c1952476" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
                       <entries/>
@@ -1879,24 +1848,19 @@ All other rules apply</description>
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="ada1d84c-e666-f7f8-e63d-58a71783fe95" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-        <rule id="e7fd8318-0a82-0773-63f7-cf022781a7b8" name="Combat Squads" hidden="false" book="Codex: Dark Angels 6th" page="28">
-          <description>A 10-man unit with this rule can break down into two 5-man units.
-You must decide which units are splitting into combat squads, and which models go into which combat squad BEFORE deployment, for all pourposes they are two seperate units.
-Note: two combat squads split from the same unit may share tansport space in the same transport vehicle.</description>
-          <modifiers/>
-        </rule>
-        <rule id="46a77193-d14f-282b-adb5-d8845526d1df" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-          <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="16a2a28b-67a7-76dc-e771-eeaf7cd2fabf" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9facbbb8-2f83-7777-7b95-17e8e21957de" targetId="ccb665c3-6839-4522-3b01-c52f525edfad" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="af248b9b-d0d3-c003-c2bf-fec3417e0720" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="ca7afccf-ee37-ccd7-0627-fa8de1534c99" name="Azrael" points="215.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="52">
       <entries>
@@ -2007,23 +1971,6 @@ Note: two combat squads split from the same unit may share tansport space in the
           </profiles>
           <links/>
         </entry>
-        <entry id="06bafcfc-c413-b4af-49cf-8621401caf11" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="71d23e7d-de78-184e-9c64-795b4c120c07" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="5779647d-0709-ec08-c27b-fbc79140e25e" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
       </entries>
       <entryGroups>
         <entryGroup id="c943c712-1997-a4b6-5734-6bb5e7c79d3f" name="Basic Wargear" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
@@ -2093,21 +2040,6 @@ Note: two combat squads split from the same unit may share tansport space in the
           <description>All models in Codex: Dark Angels 6th use his Azrael&apos;s Ledership as long as he is on the table.</description>
           <modifiers/>
         </rule>
-        <rule id="4acb66b4-cf15-c85f-886d-787164b8ca66" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles>
         <profile id="df385a55-2d04-9d26-c762-3f663de32a3b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Azrael" hidden="false" book="Codex: Dark Angels 6th" page="52">
@@ -2126,7 +2058,14 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="6c9160f4-79fd-30c5-a3da-8e984e74fe10" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1abf0191-a0bb-ee32-702b-e63798c25857" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="47dbe873-d068-d716-369b-664d7994667f" name="Belial" points="190.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="56">
       <entries>
@@ -3134,29 +3073,16 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="d83620ea-41cd-18ea-86ff-77cec3bca740" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
-        <rule id="64406d3f-9c96-17c5-e0bc-aa7ae6b32700" name="Zealot" hidden="false" book="BRB" page="43">
-          <description>Unit this Character is joined to has Fearless and Hatred (Everything)</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="05f90bbd-53ae-18a7-d366-b263aaf24e0f" targetId="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e2e8ba1f-66be-1701-35d0-4d148433a283" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="33eafc00-0f95-5385-ff20-5df4bbd91f8d" name="Command Squad" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="0" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="33">
       <entries>
@@ -3224,23 +3150,6 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="2c2e0738-0a74-83fb-0497-55c3036b4c92" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="5ce0e8c1-c00d-7907-347d-e93a06739691" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="1873f564-8d9b-39a8-bcd9-ed38b9eab46f" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
         <entry id="117ca857-7195-966f-879b-05eee0e83eee" name="Apothecary" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
@@ -4342,14 +4251,16 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules>
-        <rule id="f580b03e-e021-3ec0-efe8-b130cb5b7bc9" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="d113f3fd-fb76-42ad-6fdf-82bfdd7696c6" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d88ee475-e5f5-6b3f-31e0-5a577bf3cbb1" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="304a47ec-d6ee-d390-f5cc-ee15e5f43401" name="Company Master" points="90.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="29">
       <entries>
@@ -4396,23 +4307,6 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="af7a2d65-55f3-969c-5bee-784b0f7998e9" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="70c17ada-141b-4476-4693-0c49ec1a823d" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="5412e4e3-e75b-4235-6f78-3b829c7ea860" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
       </entries>
@@ -5991,25 +5885,16 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="78302cdc-473b-f281-fe03-d1b773943ef3" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="44af6560-4b72-827a-7f55-b1a8780aa451" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="d646f670-74ae-4bbc-7957-474d4b504448" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="58153ee2-b9b6-32e2-1703-e69210584fd9" name="Company Veterans Squad" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -6105,23 +5990,6 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="016b206d-8393-4190-ea8c-d2bce929e9ae" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="51dd81b8-4c6b-25e5-a628-ec39ac2d8886" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="88670bc6-6ea5-f0d9-72fd-5eb4695335a8" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
         <entry id="4e647d79-67a0-de27-f14c-dfb556066d0d" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
@@ -7163,20 +7031,19 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="26859049-fa6e-9e50-7829-847f8a19be69" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-        <rule id="ca71755c-6d60-5a40-fde8-6810b85ac5fe" name="Combat Squads" hidden="false" book="Codex: Dark Angels 6th" page="28">
-          <description>A 10-man unit with this rule can break down into two 5-man units.
-You must decide which units are splitting into combat squads, and which models go into which combat squad BEFORE deployment, for all pourposes they are two seperate units.
-Note: two combat squads split from the same unit may share tansport space in the same transport vehicle.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="94a8d2e6-322e-471f-6f0f-836d118c1dcc" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="501f57b7-ddd6-a82b-9259-18b6bea6e7e5" targetId="ccb665c3-6839-4522-3b01-c52f525edfad" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d3447d24-21f7-1858-03a6-0a83c645c497" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="8a24e14f-6188-525d-aa9f-a07b5a247d9e" name="Deathwing Command Squad" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="0" collective="false" hidden="false" page="0">
       <entries>
@@ -8260,10 +8127,6 @@ Note: two combat squads split from the same unit may share tansport space in the
 Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
           <modifiers/>
         </rule>
-        <rule id="2a1151ce-d801-f839-6310-1d905cfc53db" name="Split Fire" hidden="false" book="BRB" page="42">
-          <description>Take A leadership test, if passed each model may fire at a different target than the rest of the unit, if failed all models fire at the same target</description>
-          <modifiers/>
-        </rule>
         <rule id="737e0baf-d276-5fb2-fa75-c64fa5e12ffb" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
           <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
           <modifiers/>
@@ -8280,7 +8143,11 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="58a2ebbe-3cce-1e0f-a464-818a26c28027" targetId="bca26196-b0ac-5c0f-7973-87bba207a044" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="390cf30b-0755-a0ec-4caf-63f0dea4ce09" name="Deathwing Knights" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -9084,21 +8951,20 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
 Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
           <modifiers/>
         </rule>
-        <rule id="1f29218f-65e8-7007-7dca-35f3e8190312" name="Hammer of Wrath" hidden="false" page="0">
-          <description>On the turn this unit charges into combat they get an Initiative 10 hit at their unmodified Strength for each model with this rule.</description>
-          <modifiers/>
-        </rule>
-        <rule id="12ae1d0f-8884-b7c9-15ad-9a31650c98f4" name="You Cannot Hide" hidden="false" page="0">
-          <description>Gain a precision strike on a 6 in close combat</description>
-          <modifiers/>
-        </rule>
         <rule id="e883398f-7799-cfa2-17ff-75cb102ce9ae" name="Fortress of Shields" hidden="false" page="0">
           <description>Any model with the Inner Circle rule that is in base contact with a two models with this rule gain +1 Toughness</description>
           <modifiers/>
         </rule>
       </rules>
       <profiles/>
-      <links/>
+      <links>
+        <link id="71739b05-6b7c-4df0-aa95-02b3fae93f4d" targetId="e686a9c6-b3c3-dabc-918a-6aebf64cf097" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0f38ca2b-1f29-9704-f0d4-9c0c817d8da6" targetId="2355b566-5ba0-5513-ba21-d72374806af3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="3c9755ab-37a1-4c06-68ec-4d38b0f6c967" name="Deathwing Terminator Squad" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -10072,10 +9938,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
 Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
           <modifiers/>
         </rule>
-        <rule id="8895991a-8999-c341-bbcc-b76e2e8e173a" name="Split Fire" hidden="false" book="BRB" page="42">
-          <description>Take A leadership test, if passed each model may fire at a different target than the rest of the unit, if failed all models fire at the same target</description>
-          <modifiers/>
-        </rule>
         <rule id="8ed98eef-c327-cbba-b198-c7a6ced18928" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
           <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
           <modifiers/>
@@ -10089,7 +9951,11 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="9334968c-f4dd-f0a4-2f20-7efb847341fd" targetId="bca26196-b0ac-5c0f-7973-87bba207a044" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="196bd4f0-7267-4337-cef4-e528d9d96ce5" name="Deathwing Terminator Squad (Troops)" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="0" collective="false" hidden="false" page="0">
       <entries>
@@ -11079,10 +10945,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
 Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
           <modifiers/>
         </rule>
-        <rule id="8ff37816-45ea-0041-165e-401915b308d4" name="Split Fire" hidden="false" book="BRB" page="42">
-          <description>Take A leadership test, if passed each model may fire at a different target than the rest of the unit, if failed all models fire at the same target</description>
-          <modifiers/>
-        </rule>
         <rule id="ca9486d9-71c8-dc69-432e-30115b87a199" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
           <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
           <modifiers/>
@@ -11096,7 +10958,11 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="ac5a7a45-dbea-570c-ece9-4e4e3748e2ca" targetId="bca26196-b0ac-5c0f-7973-87bba207a044" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="8a60c6bb-792a-a0cd-eacd-79c123bc3ee5" name="Devastator Squad" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -11689,23 +11555,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           </profiles>
           <links/>
         </entry>
-        <entry id="cfc298ae-1809-0268-5521-186f4608ca4a" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="030f3da2-f05b-73eb-bd31-a1f599aafa29" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="6fdbf917-feeb-0b6f-a1b6-76f2c7293135" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
       </entries>
       <entryGroups>
         <entryGroup id="979cb70d-59db-c742-14a4-b6233f1103da" name="Transport" defaultEntryId="cb1c2660-875a-299d-4bfc-ea174b891d94" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
@@ -11860,20 +11709,19 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="5d20b9ab-fcdb-cce5-a66f-f58157d57733" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-        <rule id="dc76b9af-af51-0092-2789-4207ac362e8b" name="Combat Squads" hidden="false" book="Codex: Dark Angels 6th" page="28">
-          <description>A 10-man unit with this rule can break down into two 5-man units.
-You must decide which units are splitting into combat squads, and which models go into which combat squad BEFORE deployment, for all pourposes they are two seperate units.
-Note: two combat squads split from the same unit may share tansport space in the same transport vehicle.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="35606292-72fc-c3a9-3a01-cd65fde1e6c6" targetId="ccb665c3-6839-4522-3b01-c52f525edfad" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7ab723f8-9daa-8394-b54f-ed6677de3844" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d84d6828-aaf5-1912-279f-8fe8a3c9adce" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="e4040392-04bf-0950-5f8a-2dd98a17fee4" name="Dreadnought" points="100.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -12524,23 +12372,6 @@ Note: two combat squads split from the same unit may share tansport space in the
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="e03a650c-7c83-6c33-1e11-7390936cf7b2" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="2cbbc465-ba84-b26b-c12e-1a347b708dc5" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="7e00b30a-a6d8-971d-36e8-642dbc8fdd4c" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
       </entries>
@@ -13808,29 +13639,19 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="0e302130-f6e9-5534-d87f-c66710aed4b5" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
-        <rule id="2ca7f9b9-e9bd-c9f4-09bb-ab001b1a5fc8" name="Zealot" hidden="false" book="BRB" page="43">
-          <description>Unit this Character is joined to has Fearless and Hatred (Everything)</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="d632c34d-52bc-cdd3-e651-a9fea128af8f" targetId="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3b83fff2-7339-f6de-6344-76a12928f17f" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d697127b-b466-841b-a88e-802a096a65a9" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="6f22a1b0-a00d-e35a-118a-d9df6776915d" name="Land Raider" points="250.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -14526,12 +14347,7 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="03c2920f-a4d6-6058-5649-0361f6e2ee1a" name="Deep Strike" hidden="false" book="BRB" page="36">
-          <description>Read the BRB, it&apos;s too complicated to explain in a small space.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="c62b3538-04fb-805f-f94e-1d12dfaa7100" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Landspeeder Vengance" hidden="false" page="0">
           <characteristics>
@@ -14545,27 +14361,14 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="5571241a-53b2-bb2c-a482-e151dd508200" targetId="c03c1ce3-b2c1-d69b-30db-b6d95138e2d3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="46dc8ac6-864d-0179-66e5-dd492320768c" name="Librarian" points="65.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="31">
       <entries>
-        <entry id="8749e4b1-3f7a-26d1-ab75-783d06279e12" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="3fcca6e1-071a-724c-6b02-ac4bb9116f77" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="f7ab689c-0fe1-5830-4dfc-4be4e9f47b54" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="6a4af0bd-c994-ec92-55e4-492bc8c741df" name="Psyker" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups>
@@ -15930,25 +15733,16 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="4c130314-a072-f069-8f8a-1266be7f7295" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="39e31be7-98f7-30f4-8671-f28518bf372d" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="6ca27508-14cd-6645-2610-56c3453cc943" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="0d4c75d1-7d3d-43d7-ca44-02cc0eec3fc6" name="Nephilim Jetfighter" points="180.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -18533,23 +18327,6 @@ If held in reserve, the unit gains outflank.</description>
           </profiles>
           <links/>
         </entry>
-        <entry id="61b72995-fc6b-12cc-9c67-5843c2e744df" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="bf44437c-e70e-8585-edd6-7feb34b15925" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="d841dada-69c3-30a1-88e1-71600d39e308" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="c455ed56-9f1f-44ff-f506-c5a0a33a91a3" name="Power Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -18725,28 +18502,25 @@ If held in reserve, the unit gains outflank.</description>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules>
-        <rule id="320c1e0c-b1e6-dcf2-dcee-382b57c714dc" name="Skilled Rider" hidden="false" book="BRB" page="41">
-          <description>Automatically passes Dangerous Terrain and recieves +1 to Jink saves</description>
-          <modifiers/>
-        </rule>
-        <rule id="4468298c-6beb-e692-b706-3fc51fe4f7b1" name="Scouts" hidden="false" book="BRB" page="41">
-          <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
-Any unit that redelpoys with this rule may not charge on the first turn.
-If held in reserve, the unit gains outflank.</description>
-          <modifiers/>
-        </rule>
-        <rule id="373054d9-0d92-af1f-4310-b34501e75549" name="Hit &amp; Run" hidden="false" book="BRB" page="38">
-          <description>Take an Initiative test at the end of the assault phase, if succesful choose a direction and roll 3D6, move that far ignoring all models in base contact, if this would take you within 1&quot; of another unit stop 1&quot; away, treat all terrain as dangerous. The unit left makes an immediate D6&quot; consolidation. </description>
-          <modifiers/>
-        </rule>
-        <rule id="ae4b9d4e-6274-6658-3f92-a451c16ffd26" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="ec7bd4b7-8b4a-a593-6836-17ba81d05200" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c63b30da-6025-5899-0473-cbeadc32d503" targetId="5d37847f-4c54-a134-0728-fa97a76e0fbc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="abaefb5b-4d0d-2f11-3adb-8f5e48089427" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a7c484ca-5883-e603-eb31-96a30c6f9ec1" targetId="093fc456-1d4f-01fb-c223-132bc01fe497" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d3864286-110a-a53b-7b87-c26d3d7bed76" targetId="153beb27-ddea-bb1d-d61e-9dd5b1771124" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="3eaeaf88-c265-125e-a0fa-c16174d3a4ae" name="Ravenwing Darkshroud" points="80.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries/>
@@ -18797,22 +18571,12 @@ If held in reserve, the unit gains outflank.</description>
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="6224783c-9d59-0d04-009a-4fca09fb5435" name="Deep Strike" hidden="false" book="BRB" page="36">
-          <description>Read the BRB, it&apos;s too complicated to explain in a small space.</description>
-          <modifiers/>
-        </rule>
         <rule id="4be30665-d47e-d357-6852-db69ea433177" name="Icon of Old Caliban" hidden="false" page="0">
           <description>Friendly Dark Angels within 12&quot; add 1 to their combat resolution</description>
           <modifiers/>
         </rule>
         <rule id="6c69b8ff-b7ce-e6eb-5918-da28f4a98b80" name="Shroud of Angels" hidden="false" page="0">
           <description>The Darkshroud has Shrouded Special Rule and all friendlies within 6&quot; have stealth</description>
-          <modifiers/>
-        </rule>
-        <rule id="1ac22326-57ab-5120-eee2-975dfd455972" name="Scouts" hidden="false" book="BRB" page="41">
-          <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
-Any unit that redelpoys with this rule may not charge on the first turn.
-If held in reserve, the unit gains outflank.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -18829,7 +18593,14 @@ If held in reserve, the unit gains outflank.</description>
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="6a344d36-0b91-9305-7172-84b9f39111b1" targetId="c03c1ce3-b2c1-d69b-30db-b6d95138e2d3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7c88aecb-a3e4-a079-c68d-7193eafcc35b" targetId="093fc456-1d4f-01fb-c223-132bc01fe497" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="952c5295-584b-8f5a-fae5-3b790acbbe75" name="Ravenwing Darktalon" points="160.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -20045,14 +19816,7 @@ If held in reserve, the unit gains outflank.</description>
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="f3abc5e7-97a6-bcb8-3e6f-c7d860983fcb" name="Scouts" hidden="false" book="BRB" page="41">
-          <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
-Any unit that redelpoys with this rule may not charge on the first turn.
-If held in reserve, the unit gains outflank.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="2e1c7d44-16c5-d6ca-cfa0-9bd9d82d1c02" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Scouts" hidden="false" page="0">
           <characteristics>
@@ -20070,7 +19834,23 @@ If held in reserve, the unit gains outflank.</description>
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="f93211f9-ad3f-13a0-62f1-bc7ceb4449d3" targetId="093fc456-1d4f-01fb-c223-132bc01fe497" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6a4e8010-7fbe-032b-f22a-59ba64737107" targetId="c69b7c85-fb0d-5d3a-9284-42e4f77cf247" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="29f12641-24e1-3715-47a5-e0d15639237b" targetId="723a6b38-cca2-b9ac-8a86-e5dac5582c34" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="40b48ca1-8dac-caf2-a324-37a86b49867f" targetId="ccb665c3-6839-4522-3b01-c52f525edfad" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="39e91102-0535-02fe-2988-a77f27358162" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="64a789e7-9153-9dae-1b10-14f7466afe88" name="Tactical Squad" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -20632,23 +20412,6 @@ If held in reserve, the unit gains outflank.</description>
           </profiles>
           <links/>
         </entry>
-        <entry id="d88522d1-b077-2e67-dd60-2b2b888bd092" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="7ab50f39-6553-3218-df12-0d5fb20471e8" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="46d0a3cf-209a-d1e2-8125-94e9d46002bf" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="b323defc-fd67-be1f-ce79-30b10a57f074" name="Boltgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
           <entries/>
           <entryGroups/>
@@ -20896,14 +20659,19 @@ If held in reserve, the unit gains outflank.</description>
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="61ce57b0-29ca-580e-9d11-ad293898f14f" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="1166d4af-9c71-792c-7b44-1f2318ef89d3" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1ef0aa7d-6d7c-4c34-3063-4be3f0f3d7d5" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4179e728-59ea-824c-cf46-fc9688cb0646" targetId="ccb665c3-6839-4522-3b01-c52f525edfad" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="7bfcba98-2870-7155-d219-3bab0a7a256d" name="Techmarine" points="50.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="0" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="32">
       <entries>
@@ -20956,23 +20724,6 @@ If held in reserve, the unit gains outflank.</description>
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="d8456315-5679-7353-b632-3aca18f06696" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="cd3ad097-7334-a1af-fcac-bbce663302d9" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="aa867eb4-6c2c-2c81-da63-94b520045295" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
         <entry id="ed9c778a-6f31-88b1-0dea-5091ea5a9365" name="Servitors" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="32">
@@ -21794,28 +21545,19 @@ If the result is 5 or more you may either restore a Hull Point or repair a Weapo
           <description>After Deployment, but before Scout and Infiltrators, nominate one peice of terrain in your deployment zone, the terrain&apos;s cover is increased by 1 to a maximum of 2+</description>
           <modifiers/>
         </rule>
-        <rule id="43bab4ba-a806-d0af-3402-a02d14cff123" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
-        <rule id="21b320bc-e4db-a02f-0731-972c0e88bd2d" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles/>
-      <links/>
+      <links>
+        <link id="408c9f00-7051-d1d9-49f1-2024d65a6ae8" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4c73a955-993e-5fef-2fd5-d5576906ce9b" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="12a5c322-4100-2849-c5bf-de17a3352e63" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="42478a02-d484-5292-9f73-4cd657dfea7c" name="Vindicator" points="125.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -22469,18 +22211,16 @@ D6 VEHICLE TARGET
       <entries/>
       <entryGroups/>
       <modifiers/>
-      <rules>
-        <rule id="f543a10d-f54f-3ade-a32f-1ed197c37bc8" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-          <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-          <modifiers/>
-        </rule>
-        <rule id="bf6eed91-5e9a-28ea-c881-19b46f4ac7c2" name="Fearless" hidden="false" book="BRB" page="35">
-          <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="663b9e7a-c934-dbd2-6fc2-a8be5cc40364" targetId="e44b8d08-ba96-44e9-e90e-7db14cf4d747" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="36e4021e-939c-351a-9883-8c0120108d65" targetId="7efe725d-80ba-52f2-0b7a-3ac65b79e496" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="192a4884-01ed-cc57-b799-026ff72bfacd" name="Lion&apos;s Roar" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="67">
       <entries/>
@@ -23024,26 +22764,19 @@ D6 VEHICLE TARGET
       <entries/>
       <entryGroups/>
       <modifiers/>
-      <rules>
-        <rule id="0b09c630-f4e0-619b-112e-9e8aeb1c353c" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="36987e1a-c3df-6c78-052c-05f4390781c3" targetId="f10fad52-b01c-bccf-2863-fdd87067fd74" linkType="rule">
           <modifiers/>
-        </rule>
-        <rule id="b1a465ce-2455-e10b-cf59-421972d8d0e8" name="Deathwing Assault" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>Units composed entirely composed of models with this rule and wearing Terminator Armour can choose to make a Deathwing Assault.
-Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
+        </link>
+        <link id="542f5263-2656-599e-d080-b29b2b010474" targetId="2bab9bae-b21e-ec37-da63-5d50ea86d703" linkType="rule">
           <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="0a796df6-c333-1ff7-06cc-eaca43dd54e6" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Terminator Armour" hidden="false" book="Codex: Dark Angels 6th" page="65">
-          <characteristics>
-            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="2+/5++, have the Bulky, Deep Strike, Relentless, Deathwing Assault and Vengeful Strike special rules, and may not make sweeping advances."/>
-          </characteristics>
+        </link>
+        <link id="c9b6e63d-9622-30a7-4ff7-683e19623c9e" targetId="5d222ef2-1df8-c423-4e3b-45dd593381c8" linkType="profile">
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
+        </link>
+      </links>
     </entry>
   </sharedEntries>
   <sharedEntryGroups>
@@ -24566,19 +24299,19 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
     </entryGroup>
   </sharedEntryGroups>
   <sharedRules>
-    <rule id="eb34e872-774f-ff0f-e168-70b295fc5755" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
+    <rule id="eb34e872-774f-ff0f-e168-70b295fc5755" name="And They Shall Know No Fear" hidden="false" book="BRB" page="157">
       <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
       <modifiers/>
     </rule>
-    <rule id="01e84d3e-b6a8-6266-5548-d16770351601" name="Assault Vehicle" hidden="false" page="0">
-      <description>Passengers may assault the same turn they disembark</description>
+    <rule id="01e84d3e-b6a8-6266-5548-d16770351601" name="Assault Vehicle" hidden="false" book="BRB" page="157">
+      <description>Passengers may assault the same turn they disembark (unless the vehicle arrived from Reserve that turn.)</description>
       <modifiers/>
     </rule>
     <rule id="a2a145c6-aa9f-6cef-36a7-b4f3e5158e93" name="Bane of the Traitor" hidden="false" book="Codex: Dark Angels 6th" page="62">
       <description>When a Weapon with this Special Rule is used to attack a model from Codex: Chaos Space Marines, the AP is improved by 1 (to a max of 1)</description>
       <modifiers/>
     </rule>
-    <rule id="f0c89d80-4640-2ec5-59ee-0375d9d26fd1" name="Bulky" hidden="false" book="BRB" page="35">
+    <rule id="f0c89d80-4640-2ec5-59ee-0375d9d26fd1" name="Bulky" hidden="false" book="BRB" page="159">
       <description>Counts as two models for transport capacity.</description>
       <modifiers/>
     </rule>
@@ -24597,14 +24330,14 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
       <description>Preferred Enemy (Chaos Space Marines), you may make your opponent re-roll any vehicle damage result</description>
       <modifiers/>
     </rule>
-    <rule id="c03c1ce3-b2c1-d69b-30db-b6d95138e2d3" name="Deep Strike" hidden="false" book="BRB" page="36">
-      <description>Read the BRB, it&apos;s too complicated to explain in a small space.</description>
+    <rule id="c03c1ce3-b2c1-d69b-30db-b6d95138e2d3" name="Deep Strike" hidden="false" book="BRB" page="162">
+      <description>(Read the BRB, it&apos;s too complicated to explain in a small space.)</description>
       <modifiers/>
     </rule>
-    <rule id="ca219793-6e3f-63f3-e811-6b9920eec96a" name="Fear" hidden="false" book="BRB" page="35">
+    <rule id="ca219793-6e3f-63f3-e811-6b9920eec96a" name="Fear" hidden="false" book="BRB" page="163">
       <description>At the start of the Fight sub-phase, a unit in base contact with this model must take a Fear test.
 
-If the test is failed then the unit has it&apos;s WS reduced to 1 for the remainder of the phase.
+If the test is failed then the unit has it&apos;s WS reduced to 1 for the remainder of the sub-phase.
 
 Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are immune to this rule.</description>
       <modifiers/>
@@ -24622,18 +24355,18 @@ Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are 
       <modifiers/>
     </rule>
     <rule id="477000f9-799b-8cdf-1ff3-d443b76bdb5a" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-      <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
+      <description>A model with this rule has Stubborn and so ignores negative Leadership modifiers (BRB p172). In addition they may never choose to fail a morale check.</description>
       <modifiers/>
     </rule>
-    <rule id="e686a9c6-b3c3-dabc-918a-6aebf64cf097" name="Hammer of Wrath" hidden="false" page="0">
-      <description>On the turn this unit charges into combat they get an Initiative 10 hit at their unmodified Strength for each model with this rule.</description>
+    <rule id="e686a9c6-b3c3-dabc-918a-6aebf64cf097" name="Hammer of Wrath" hidden="false" book="BRB" page="165">
+      <description>On the turn this unit charges into combat they get an Initiative 10 automatic hit at their unmodified Strength for each model with this rule.</description>
       <modifiers/>
     </rule>
-    <rule id="13d88015-bf33-edcd-9185-88e077572e86" name="Hatred" hidden="false" book="BRB" page="37">
-      <description>Reroll all misses in the first round of each combat.</description>
+    <rule id="13d88015-bf33-edcd-9185-88e077572e86" name="Hatred" hidden="false" book="BRB" page="165">
+      <description>Reroll all misses in the first round of each close combat.</description>
       <modifiers/>
     </rule>
-    <rule id="5d37847f-4c54-a134-0728-fa97a76e0fbc" name="Hit &amp; Run" hidden="false" book="BRB" page="38">
+    <rule id="5d37847f-4c54-a134-0728-fa97a76e0fbc" name="Hit &amp; Run" hidden="false" book="BRB" page="165">
       <description>Take an Initiative test at the end of the assault phase, if succesful choose a direction and roll 3D6, move that far ignoring all models in base contact, if this would take you within 1&quot; of another unit stop 1&quot; away, treat all terrain as dangerous. The unit left makes an immediate D6&quot; consolidation. </description>
       <modifiers/>
     </rule>
@@ -24641,8 +24374,8 @@ Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are 
       <description>Friendly Dark Angels within 12&quot; add 1 to their combat resolution</description>
       <modifiers/>
     </rule>
-    <rule id="cf6ef79b-8fdc-9eec-ba81-1003561684f6" name="Independant Character" hidden="false" book="BRB" page="0">
-      <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
+    <rule id="cf6ef79b-8fdc-9eec-ba81-1003561684f6" name="Independant Character" hidden="false" book="BRB" page="166">
+      <description>Independent Characters can join and leave other units that do not contain vehicles or Monstrous Creatures. Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
 An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
 An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
 An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
@@ -24656,8 +24389,8 @@ When an Independent Character joins a unit he looses all special rules that the 
 If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
       <modifiers/>
     </rule>
-    <rule id="c69b7c85-fb0d-5d3a-9284-42e4f77cf247" name="Infiltrate" hidden="false" book="BRB" page="38">
-      <description>See page 38 of BRB</description>
+    <rule id="c69b7c85-fb0d-5d3a-9284-42e4f77cf247" name="Infiltrate" hidden="false" book="BRB" page="167">
+      <description>Deployed after all other units anywhere &gt; 12&quot; away from enemy and outside their line of sight, or &gt; 18&quot; away within LoS.  Cannot charge in first turn after deploying this way.  Also has Outflank.</description>
       <modifiers/>
     </rule>
     <rule id="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" name="Inner Circle" hidden="false" book="Codex: Dark Angels 6th" page="28">
@@ -24670,19 +24403,19 @@ On a 4+ there is no effect this turn.  On a roll of 1,2 or 3, the unit is mindlo
 A mindlocked unit may not voluntarily mov, shoot or charge.  A mindlocked unit must still make compulsory moves, such as Pile In and Fall Back moves.</description>
       <modifiers/>
     </rule>
-    <rule id="723a6b38-cca2-b9ac-8a86-e5dac5582c34" name="Move Through Cover" hidden="false" book="BRB" page="40">
-      <description>Roll an extra dice for determining distance traveled through cover and automatically pass danegerous terrain tests</description>
+    <rule id="723a6b38-cca2-b9ac-8a86-e5dac5582c34" name="Move Through Cover" hidden="false" book="BRB" page="168">
+      <description>Roll an extra dice for determining distance traveled through cover (still take highest) and automatically pass danegerous terrain tests</description>
       <modifiers/>
     </rule>
-    <rule id="5ce60ce3-3c74-d8a2-9ff9-812ba149563b" name="Outflank" hidden="false" book="BRB" page="40">
-      <description>When this unit arrives from reserves roll al dice, on a 1-2 it comes in on your left, on a 3-4 it comes in on your right and on a 5-6 you choose right or left.</description>
+    <rule id="5ce60ce3-3c74-d8a2-9ff9-812ba149563b" name="Outflank" hidden="false" book="BRB" page="168">
+      <description>When this unit arrives from reserves roll a die, on a 1-2 it comes in on your left, on a 3-4 it comes in on your right and on a 5-6 you choose right or left.</description>
       <modifiers/>
     </rule>
     <rule id="28b8dc3c-9647-8bae-7039-240a71e8e48d" name="Power of the Machine Spirit" hidden="false" page="0">
       <description>So long as the vehicle dosen&apos;t move flat out or pop smoke, it may fire an additional weapon than normal and may fire at a different target.</description>
       <modifiers/>
     </rule>
-    <rule id="7efe725d-80ba-52f2-0b7a-3ac65b79e496" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
+    <rule id="7efe725d-80ba-52f2-0b7a-3ac65b79e496" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="169">
       <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
       <modifiers/>
     </rule>
@@ -24690,7 +24423,7 @@ A mindlocked unit may not voluntarily mov, shoot or charge.  A mindlocked unit m
       <description>The Attack bike and Land speeder are purchased as part of the Squadron but will always operate as an individual, if there are 6 bikers left after the attack bike and land speeder have split, then they operate as two squadrons of 3</description>
       <modifiers/>
     </rule>
-    <rule id="282de331-103b-3c65-f3ef-d9932f77c8c1" name="Relentless" hidden="false" book="BRB" page="41">
+    <rule id="282de331-103b-3c65-f3ef-d9932f77c8c1" name="Relentless" hidden="false" book="BRB" page="170">
       <description>Counts as stationatry for firing weapons, may charge after firing any type of weapon.</description>
       <modifiers/>
     </rule>
@@ -24702,8 +24435,8 @@ A mindlocked unit may not voluntarily mov, shoot or charge.  A mindlocked unit m
       <description>In a turn in which the vehicle has not moved, the mutli-launcher’s rate of fire is increased to Heavy 1+D3.</description>
       <modifiers/>
     </rule>
-    <rule id="093fc456-1d4f-01fb-c223-132bc01fe497" name="Scouts" hidden="false" book="BRB" page="41">
-      <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
+    <rule id="093fc456-1d4f-01fb-c223-132bc01fe497" name="Scouts" hidden="false" book="BRB" page="171">
+      <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;, and all must remain 12&quot; away from enemy units.
 Any unit that redelpoys with this rule may not charge on the first turn.
 If held in reserve, the unit gains outflank.</description>
       <modifiers/>
@@ -24716,20 +24449,20 @@ If held in reserve, the unit gains outflank.</description>
       <description>Counts it&apos;s cover save as 2 better than normal (Combines with Stealth)</description>
       <modifiers/>
     </rule>
-    <rule id="153beb27-ddea-bb1d-d61e-9dd5b1771124" name="Skilled Rider" hidden="false" book="BRB" page="41">
+    <rule id="153beb27-ddea-bb1d-d61e-9dd5b1771124" name="Skilled Rider" hidden="false" book="BRB" page="171">
       <description>Automatically passes Dangerous Terrain and recieves +1 to Jink saves</description>
       <modifiers/>
     </rule>
-    <rule id="bca26196-b0ac-5c0f-7973-87bba207a044" name="Split Fire" hidden="false" book="BRB" page="42">
-      <description>Take A leadership test, if passed each model may fire at a different target than the rest of the unit, if failed all models fire at the same target</description>
+    <rule id="bca26196-b0ac-5c0f-7973-87bba207a044" name="Split Fire" hidden="false" book="BRB" page="172">
+      <description>A single model may fire at a different target before the rest of the unit.</description>
       <modifiers/>
     </rule>
     <rule id="5d203f23-635e-275e-1aef-4a42b8691464" name="Stealth" hidden="false" page="0">
       <description>Counts it&apos;s coversave as 1 point better than normal, (Combines with Shrouded)</description>
       <modifiers/>
     </rule>
-    <rule id="d012e69d-f858-e165-7c6a-0e592af5281a" name="Stubborn" hidden="false" book="BRB" page="43">
-      <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
+    <rule id="d012e69d-f858-e165-7c6a-0e592af5281a" name="Stubborn" hidden="false" book="BRB" page="172">
+      <description>Ignore all negative Ld modifiers for Morale and Pinning tests. If the unit has Fearless as well ignore this rule.</description>
       <modifiers/>
     </rule>
     <rule id="2bab9bae-b21e-ec37-da63-5d50ea86d703" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
@@ -24740,7 +24473,7 @@ If held in reserve, the unit gains outflank.</description>
       <description>Gain a precision strike on a 6 in close combat</description>
       <modifiers/>
     </rule>
-    <rule id="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" name="Zealot" hidden="false" book="BRB" page="43">
+    <rule id="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" name="Zealot" hidden="false" book="BRB" page="174">
       <description>Unit this Character is joined to has Fearless and Hatred (Everything)</description>
       <modifiers/>
     </rule>

--- a/Dark Angels - Codex.cat
+++ b/Dark Angels - Codex.cat
@@ -2059,7 +2059,7 @@ All other rules apply</description>
         </profile>
       </profiles>
       <links>
-        <link id="6c9160f4-79fd-30c5-a3da-8e984e74fe10" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+        <link id="6c9160f4-79fd-30c5-a3da-8e984e74fe10" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
           <modifiers/>
         </link>
         <link id="1abf0191-a0bb-ee32-702b-e63798c25857" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
@@ -2211,34 +2211,6 @@ All other rules apply</description>
           <description>Belial and any unit he has joined with Inner Circle rule do not scatter when Deep Striking.</description>
           <modifiers/>
         </rule>
-        <rule id="cf8a3d81-2e27-4439-608c-887b8ae2e0f9" name="Deathwing Assault" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>Units composed entirely composed of models with this rule and wearing Terminator Armour can choose to make a Deathwing Assault.
-Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
-          <modifiers/>
-        </rule>
-        <rule id="1e78a1d3-86fd-50f4-20ad-f1bcb9084ba4" name="Independant Character" hidden="false" book="BRB" page="0">
-          <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-          <modifiers/>
-        </rule>
-        <rule id="9168b0b9-7ca6-d5a7-3893-b3e464f69b51" name="Inner Circle" hidden="false" book="Codex: Dark Angels 6th" page="28">
-          <description>Fearless and Preferred Enemy (Chaos Space Marines)</description>
-          <modifiers/>
-        </rule>
-        <rule id="34f8cdd0-c9c8-e9f8-c4e9-8f3b7f08d3fc" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles>
         <profile id="1cb27538-f1ea-e508-0a31-0b2b8e0af283" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Belial" hidden="false" book="Codex: Dark Angels 6th" page="56">
@@ -2257,7 +2229,23 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="c611571e-1a60-7986-4ab6-74023855e38e" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bf7ef4ae-f1ee-cc60-ad00-ac03ee9f964d" targetId="f10fad52-b01c-bccf-2863-fdd87067fd74" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3ca855fb-9391-4903-89ea-12c08362eb7a" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7998b009-4432-88ac-859c-656739378b0c" targetId="2bab9bae-b21e-ec37-da63-5d50ea86d703" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6200ee63-62a5-b99b-3c73-2fdac4879f0e" targetId="2de4b722-e518-092c-7cb0-e88333e9eee3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="184a07e5-5e8e-4db1-eaff-f7a6156a7162" name="Cerastus Knight-Lancer" points="400.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="lancer.pdf" page="0">
       <entries>
@@ -5888,10 +5876,10 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
       <rules/>
       <profiles/>
       <links>
-        <link id="44af6560-4b72-827a-7f55-b1a8780aa451" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+        <link id="d646f670-74ae-4bbc-7957-474d4b504448" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
           <modifiers/>
         </link>
-        <link id="d646f670-74ae-4bbc-7957-474d4b504448" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+        <link id="ec071ce6-ce63-33b3-dc7f-22e07460e11f" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -7086,23 +7074,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           </profiles>
           <links/>
         </entry>
-        <entry id="dee9e1d8-6005-93cb-447d-949c329366c7" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="acbf9b5d-3f6d-a4db-1e09-5f1bfa32e0ad" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="128d8476-eb12-97d8-8ff9-39120179a01f" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="a43d6b9a-b5c8-d8a6-8c44-54b54ff2e2ac" name="Deathwing Champion" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -8121,17 +8092,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules>
-        <rule id="1818fbc0-8823-f6cb-6929-b72d11a7766e" name="Deathwing Assault" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>Units composed entirely composed of models with this rule and wearing Terminator Armour can choose to make a Deathwing Assault.
-Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
-          <modifiers/>
-        </rule>
-        <rule id="737e0baf-d276-5fb2-fa75-c64fa5e12ffb" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="9bece14f-4c45-f484-437b-6dc515781fea" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Power Fist" hidden="false" book="BRB" page="60">
           <characteristics>
@@ -8145,6 +8106,15 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
       </profiles>
       <links>
         <link id="58a2ebbe-3cce-1e0f-a464-818a26c28027" targetId="bca26196-b0ac-5c0f-7973-87bba207a044" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bbb32af1-0975-e68e-a8b5-b75328ace29a" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1c60f099-8afe-65ed-e040-d2cf14e5cfe4" targetId="f10fad52-b01c-bccf-2863-fdd87067fd74" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7ef7253f-552a-ac0e-fa0d-8cd0e26e8d63" targetId="2bab9bae-b21e-ec37-da63-5d50ea86d703" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -8289,23 +8259,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="a18259f2-316c-d1c2-292f-39fdcb5b152d" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="5b6a73b9-fe51-a42b-cb85-1b1705a35286" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="22433d5a-36c8-3093-b64f-e58babf9702b" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
       </entries>
@@ -8945,23 +8898,22 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="268e15e7-ae9b-35c0-3274-b2fc3b54d959" name="Deathwing Assault" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>Units composed entirely composed of models with this rule and wearing Terminator Armour can choose to make a Deathwing Assault.
-Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
-          <modifiers/>
-        </rule>
-        <rule id="e883398f-7799-cfa2-17ff-75cb102ce9ae" name="Fortress of Shields" hidden="false" page="0">
-          <description>Any model with the Inner Circle rule that is in base contact with a two models with this rule gain +1 Toughness</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
       <links>
         <link id="71739b05-6b7c-4df0-aa95-02b3fae93f4d" targetId="e686a9c6-b3c3-dabc-918a-6aebf64cf097" linkType="rule">
           <modifiers/>
         </link>
-        <link id="0f38ca2b-1f29-9704-f0d4-9c0c817d8da6" targetId="2355b566-5ba0-5513-ba21-d72374806af3" linkType="rule">
+        <link id="a29e393a-b6bf-1edb-fae7-762a4751f770" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7880a977-acc6-637f-c07c-87af1d9f96af" targetId="f10fad52-b01c-bccf-2863-fdd87067fd74" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bd002807-b3ea-9b59-a173-8dcb6f1c13de" targetId="d05b437f-3564-ab80-9124-96a6977dbe30" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="acf97654-fe2a-0829-16ea-89527f7ae12b" targetId="8dbde421-6cc8-72aa-0ec2-fc999e6f4dba" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -9025,23 +8977,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <entryGroups/>
           <modifiers/>
           <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="a02694cf-7e4e-1fa1-de7f-574635f0a67d" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="f848dece-50a5-3e2a-2978-f3d0e7495555" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="0a32c5cf-abeb-6200-1159-9ca0a8671084" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
           <profiles/>
           <links/>
         </entry>
@@ -9932,17 +9867,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           </conditionGroups>
         </modifier>
       </modifiers>
-      <rules>
-        <rule id="c4cafdd6-b93d-2b8f-44ed-732f28747069" name="Deathwing Assault" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>Units composed entirely composed of models with this rule and wearing Terminator Armour can choose to make a Deathwing Assault.
-Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
-          <modifiers/>
-        </rule>
-        <rule id="8ed98eef-c327-cbba-b198-c7a6ced18928" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="e3716c29-2583-1fb6-bd63-6b6eca850c80" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Teleport Homer" hidden="false" book="Codex: Dark Angels 6th" page="64">
           <characteristics>
@@ -9953,6 +9878,15 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
       </profiles>
       <links>
         <link id="9334968c-f4dd-f0a4-2f20-7efb847341fd" targetId="bca26196-b0ac-5c0f-7973-87bba207a044" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e1e7a7e1-05c9-d884-5444-3a58a6a7b394" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e24f41da-5423-fc90-8719-40064e17a052" targetId="f10fad52-b01c-bccf-2863-fdd87067fd74" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a5cae478-b242-5757-4c7a-51b5963c380d" targetId="2bab9bae-b21e-ec37-da63-5d50ea86d703" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -10033,23 +9967,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="9544d4df-e168-b6e7-9204-c92af25abd55" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="d8559da9-af16-b037-8c06-d80499ea55e1" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="f67c5f4f-cd88-e8f5-0e41-64b9043730b4" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
         </entry>
         <entry id="f25f67b5-6546-75a5-ce5b-b83ebe9dcea5" name="Cyclone Missile Launcher" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
@@ -10939,17 +10856,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           </conditionGroups>
         </modifier>
       </modifiers>
-      <rules>
-        <rule id="7c97070e-0035-ada5-00d0-fd1003121c31" name="Deathwing Assault" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>Units composed entirely composed of models with this rule and wearing Terminator Armour can choose to make a Deathwing Assault.
-Immediatly after determining Warlord Traits, tell your opponent which units are making a Deathwing Assault, and make a secret note on weather it happens during turn 1 or turn 2. All units chosen arrive then with no need to roll for deep strike reserves.</description>
-          <modifiers/>
-        </rule>
-        <rule id="ca9486d9-71c8-dc69-432e-30115b87a199" name="Vengeful Strike" hidden="false" book="Codex: Dark Angels 6th" page="44">
-          <description>When a model with this rule arrives from Deep Strike, it treats all ranged weapons as having Twin Linked until end of turn.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="5d441b90-b206-297d-aa9d-57d8df57572c" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Teleport Homer" hidden="false" book="Codex: Dark Angels 6th" page="64">
           <characteristics>
@@ -10960,6 +10867,15 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
       </profiles>
       <links>
         <link id="ac5a7a45-dbea-570c-ece9-4e4e3748e2ca" targetId="bca26196-b0ac-5c0f-7973-87bba207a044" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="272114db-b021-5b27-689e-0d8102ea2005" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1558b1d2-65f5-6adc-c988-63332dfea2fb" targetId="2bab9bae-b21e-ec37-da63-5d50ea86d703" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d503cd7d-b250-2ef7-e57e-8c58f0d8c026" targetId="f10fad52-b01c-bccf-2863-fdd87067fd74" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -11741,25 +11657,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <links/>
         </entry>
         <entry id="178bfe04-538a-8144-5e9a-b3cdcb46036a" name="Venerable Dreadnought" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="e728d96e-6f35-ad4c-3bba-099ccb1bc8b4" name="Deathwing Vehicle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="40">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules>
-                <rule id="055a923c-fd66-606e-085b-17d7ea1c2003" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-                  <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-                  <modifiers/>
-                </rule>
-                <rule id="20ac54ce-a4b4-3b05-ed9f-73c759f97633" name="Deathwing Vehicle" hidden="false" page="0">
-                  <description>Preferred Enemy (Chaos Space Marines), you may make your opponent re-roll any vehicle damage result</description>
-                  <modifiers/>
-                </rule>
-              </rules>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -11780,7 +11678,11 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
+          <links>
+            <link id="1b2318a4-7877-aabb-c248-ad468442df35" targetId="891fd8ee-5c99-a592-0750-48e49b5134fc" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
         </entry>
         <entry id="94664a2f-1933-9390-94d9-e55d74bbdf18" name="Smoke Launchers and Searchlight" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
           <entries/>
@@ -12308,23 +12210,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           </profiles>
           <links/>
         </entry>
-        <entry id="d63d0acc-c7fb-2e49-130c-35a1cc8c6ad9" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="88986cc2-1098-12e5-584e-eed26cf8d239" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-              <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-              <modifiers/>
-            </rule>
-            <rule id="d56e01ac-bfd3-1996-4097-5e2308c07f53" name="Fearless" hidden="false" book="BRB" page="35">
-              <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
       </entries>
       <entryGroups/>
       <modifiers/>
@@ -12355,7 +12240,14 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="4b6d6370-4961-c74e-1261-d3733f9558d3" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="24f6ce93-6cdd-9155-71df-a5edc3edc747" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="3d122a91-19f2-ddf0-52c6-08d1a9e3bc25" name="Interrogator-Chaplain" points="110.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="Codex: Dark Angels 6th" page="30">
       <entries>
@@ -13648,7 +13540,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         <link id="3b83fff2-7339-f6de-6344-76a12928f17f" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
           <modifiers/>
         </link>
-        <link id="d697127b-b466-841b-a88e-802a096a65a9" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+        <link id="e2ed7688-9c32-23dd-877e-f94bf6e33e0c" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -13824,16 +13716,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="11a4626e-3ddc-a075-e314-2ae3e24f655f" name="Assault Vehicle" hidden="false" page="0">
-          <description>Passengers may assault the same turn they disembark</description>
-          <modifiers/>
-        </rule>
-        <rule id="54786678-badf-493f-8256-6d924b3fd87c" name="Power of the Machine Spirit" hidden="false" page="0">
-          <description>So long as the vehicle dosen&apos;t move flat out or pop smoke, it may fire an additional weapon than normal and may fire at a different target.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="fdcdffed-3418-ca80-fb0d-6526eb23ede0" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Land Raider" hidden="false" page="0">
           <characteristics>
@@ -13847,7 +13730,14 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="42fa9012-3f77-28a1-9d9b-3f17511048fd" targetId="28b8dc3c-9647-8bae-7039-240a71e8e48d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ff277877-dc4d-9985-5933-8d729f25741e" targetId="01e84d3e-b6a8-6266-5548-d16770351601" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="84f4dc06-8a0b-e3b1-d3b0-5a8bd2035a95" name="Land Raider Crusader" points="250.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -14035,16 +13925,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="00ceb672-83a1-4600-734e-b6d5e5cb4bc6" name="Assault Vehicle" hidden="false" page="0">
-          <description>Passengers may assault the same turn they disembark</description>
-          <modifiers/>
-        </rule>
-        <rule id="89ecb671-0161-ab1a-3bb4-3332d8798657" name="Power of the Machine Spirit" hidden="false" page="0">
-          <description>So long as the vehicle dosen&apos;t move flat out or pop smoke, it may fire an additional weapon than normal and may fire at a different target.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="1a2fc8f8-3795-90f9-05f9-d7f82b7d2c2c" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Land Raider" hidden="false" page="0">
           <characteristics>
@@ -14058,7 +13939,14 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="345afc05-a0f4-8091-dec5-6eb01d04fc43" targetId="01e84d3e-b6a8-6266-5548-d16770351601" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f3ca13d1-dc2e-93a7-4e29-aa95c1afe5c9" targetId="28b8dc3c-9647-8bae-7039-240a71e8e48d" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="f2177167-e682-fe5e-63d2-7d791480b454" name="Land Raider Redeemer" points="245.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -14246,16 +14134,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules>
-        <rule id="2403439f-5c6e-a010-3558-b327c49cfee9" name="Assault Vehicle" hidden="false" page="0">
-          <description>Passengers may assault the same turn they disembark</description>
-          <modifiers/>
-        </rule>
-        <rule id="14572e0f-6fcb-e6b3-4688-058d2f945b7e" name="Power of the Machine Spirit" hidden="false" page="0">
-          <description>So long as the vehicle dosen&apos;t move flat out or pop smoke, it may fire an additional weapon than normal and may fire at a different target.</description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles>
         <profile id="a9f0db1b-1699-bc0f-5bbf-c0dc6a712867" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Land Raider" hidden="false" page="0">
           <characteristics>
@@ -14269,7 +14148,14 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
         </profile>
       </profiles>
-      <links/>
+      <links>
+        <link id="0026db76-519d-0d0c-16fd-bbb30357a867" targetId="01e84d3e-b6a8-6266-5548-d16770351601" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ff64ef24-d8c3-de4d-e151-9e6d3cbe41ee" targetId="28b8dc3c-9647-8bae-7039-240a71e8e48d" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="765b4ddd-828a-4182-ecec-81166552b54c" name="Land Speeder Vengance" points="140.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -14409,7 +14295,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           <modifiers/>
           <rules>
             <rule id="5f551792-24d4-ed9a-9b2b-a4152b37cad3" name="Psyker" hidden="false" page="0">
-              <description>Dark Angeles Librarians are Psykers who use the Divination, Pyromancy, Telepathy and Telekinesis disciplines.</description>
+              <description>Dark Angeles Librarians are Psykers who use the Divination, Daemonology (FAQ), Pyromancy, Telepathy and Telekinesis disciplines.</description>
               <modifiers/>
             </rule>
           </rules>
@@ -15736,10 +15622,10 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
       <rules/>
       <profiles/>
       <links>
-        <link id="39e31be7-98f7-30f4-8671-f28518bf372d" targetId="d7631e0b-54d0-b183-6929-4b2e34d12dce" linkType="entry">
+        <link id="6ca27508-14cd-6645-2610-56c3453cc943" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
           <modifiers/>
         </link>
-        <link id="6ca27508-14cd-6645-2610-56c3453cc943" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+        <link id="30c6ce75-439f-2d2f-09f0-9b787b0c523a" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -16558,23 +16444,6 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
           </profiles>
           <links/>
         </entry>
-        <entry id="b92e83ac-c5b5-cfee-b46e-b851d6b083c7" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="990f047d-d339-be4d-d954-8b32897ab1f5" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="bec9d39d-9d52-f9cd-676c-bc3a551906c3" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="d3266530-dba9-3070-7f1c-d99d10bd3bac" name="Power Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -16914,27 +16783,26 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
         </modifier>
       </modifiers>
       <rules>
-        <rule id="2dd1cbde-3e59-a03a-eb29-50246b24ac5a" name="Hit &amp; Run" hidden="false" book="BRB" page="38">
-          <description>Take an Initiative test at the end of the assault phase, if succesful choose a direction and roll 3D6, move that far ignoring all models in base contact, if this would take you within 1&quot; of another unit stop 1&quot; away, treat all terrain as dangerous. The unit left makes an immediate D6&quot; consolidation. </description>
-          <modifiers/>
-        </rule>
-        <rule id="ea7e47d6-96d9-ce78-18e2-bb3d671bf4a3" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
         <rule id="ece90ef2-e50b-2f35-ead3-a085eddc7c56" name="Ravenwing Combat Squads" hidden="false" page="0">
           <description>The Attack bike and Land speeder are purchased as part of the Squadron but will always operate as an individual, if there are 6 bikers left after the attack bike and land speeder have split, then they operate as two squadrons of 3</description>
           <modifiers/>
         </rule>
-        <rule id="dd7eb7b7-d358-808e-1a35-506d07630cc5" name="Scouts" hidden="false" book="BRB" page="41">
-          <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
-Any unit that redelpoys with this rule may not charge on the first turn.
-If held in reserve, the unit gains outflank.</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles/>
-      <links/>
+      <links>
+        <link id="54d3a76f-4bc0-b7d6-6e68-d8f9ae790c0e" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="99e74b9d-53f6-f3ce-69aa-c59b0f95e607" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bda3f25c-9460-bbd8-76fc-c4e30b7ec529" targetId="093fc456-1d4f-01fb-c223-132bc01fe497" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3a4b296b-9709-1ee1-7ba4-4dde29517c0c" targetId="5d37847f-4c54-a134-0728-fa97a76e0fbc" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="0e2235c3-3c97-5b0c-5826-597244fd6892" name="Ravenwing Attack Squadron (Troops)" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="0" collective="false" hidden="false" page="0">
       <entries>
@@ -17422,23 +17290,6 @@ If held in reserve, the unit gains outflank.</description>
           </profiles>
           <links/>
         </entry>
-        <entry id="83b50c14-3f04-e486-5136-48acd9662f08" name="Grim Resolve" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="a517b3ce-9c24-74f9-8c87-c22096ae5f8b" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
-              <description>A model with this rule has Stubborn. In addition they may never choose to fail a morale check.</description>
-              <modifiers/>
-            </rule>
-            <rule id="d851d507-a750-6219-f979-f93b9884752d" name="Stubborn" hidden="false" book="BRB" page="43">
-              <description>Ignore all negative Ld modifiers, if the unit has Fearless as well ignore this rule.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="986eae84-a668-063d-b54f-5b629fb81bfc" name="Power Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -17778,27 +17629,26 @@ If held in reserve, the unit gains outflank.</description>
         </modifier>
       </modifiers>
       <rules>
-        <rule id="42cafdb3-c050-1284-9c91-aef7f47abfa3" name="Hit &amp; Run" hidden="false" book="BRB" page="38">
-          <description>Take an Initiative test at the end of the assault phase, if succesful choose a direction and roll 3D6, move that far ignoring all models in base contact, if this would take you within 1&quot; of another unit stop 1&quot; away, treat all terrain as dangerous. The unit left makes an immediate D6&quot; consolidation. </description>
-          <modifiers/>
-        </rule>
-        <rule id="59bda1a5-3564-fea0-d2de-d96800778c42" name="And They Shall Know No Fear" hidden="false" book="BRB" page="33">
-          <description>Automatically regroups, can act normally on the turn it regroups, not killed by sweeping advances and is immune to fear.</description>
-          <modifiers/>
-        </rule>
         <rule id="d820fedf-16d9-8533-20ca-dd8f2986fa50" name="Ravenwing Combat Squads" hidden="false" page="0">
           <description>The Attack bike and Land speeder are purchased as part of the Squadron but will always operate as an individual, if there are 6 bikers left after the attack bike and land speeder have split, then they operate as two squadrons of 3</description>
           <modifiers/>
         </rule>
-        <rule id="c8888892-c186-10b5-537f-5693e43730e8" name="Scouts" hidden="false" book="BRB" page="41">
-          <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
-Any unit that redelpoys with this rule may not charge on the first turn.
-If held in reserve, the unit gains outflank.</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles/>
-      <links/>
+      <links>
+        <link id="fbc6a238-63cf-e52a-2fab-76ec130043da" targetId="093fc456-1d4f-01fb-c223-132bc01fe497" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="04897e08-c6ad-3c44-71c5-bcbfeebc931f" targetId="eb34e872-774f-ff0f-e168-70b295fc5755" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1e06f20a-0718-7b53-1281-34f5d1902222" targetId="5d37847f-4c54-a134-0728-fa97a76e0fbc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="aab429e9-110c-dc97-3fc9-c66a9fa74354" targetId="477000f9-799b-8cdf-1ff3-d443b76bdb5a" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="7f72619c-14c3-a4f8-fed3-e45743ca8706" name="Ravenwing Black Knights" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -18862,12 +18712,7 @@ Skill and Initiative, to a minimum of 1, until the end of the turn. This replace
             </entryGroup>
           </entryGroups>
           <modifiers/>
-          <rules>
-            <rule id="e7b5bc66-8869-9473-d6e0-4cea46fc604a" name="Deep Strike" hidden="false" book="BRB" page="36">
-              <description>Read the BRB, it&apos;s too complicated to explain in a small space.</description>
-              <modifiers/>
-            </rule>
-          </rules>
+          <rules/>
           <profiles>
             <profile id="7dcfe25e-c1f1-7139-6fd2-bc25418f72cd" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Land Speeder" hidden="false" page="0">
               <characteristics>
@@ -18881,7 +18726,11 @@ Skill and Initiative, to a minimum of 1, until the end of the turn. This replace
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
+          <links>
+            <link id="f8956928-a9d0-9127-9185-2f6de531b645" targetId="c03c1ce3-b2c1-d69b-30db-b6d95138e2d3" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
         </entry>
       </entries>
       <entryGroups/>
@@ -19068,23 +18917,6 @@ Skill and Initiative, to a minimum of 1, until the end of the turn. This replace
                   </profiles>
                   <links/>
                 </entry>
-                <entry id="803750e1-ddb8-f486-be3b-1aa11b8ebbad" name="Inner Circle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="11503709-b656-552c-ab29-0530cf6a77d4" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="40">
-                      <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
-                      <modifiers/>
-                    </rule>
-                    <rule id="af59d04f-e26b-5f4d-a022-8e5e45c7da3c" name="Fearless" hidden="false" book="BRB" page="35">
-                      <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
-                      <modifiers/>
-                    </rule>
-                  </rules>
-                  <profiles/>
-                  <links/>
-                </entry>
                 <entry id="47992755-c89e-8c7e-89f6-b60898764814" name="Raven Sword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
                   <entries/>
                   <entryGroups/>
@@ -19119,37 +18951,7 @@ Skill and Initiative, to a minimum of 1, until the end of the turn. This replace
               </entries>
               <entryGroups/>
               <modifiers/>
-              <rules>
-                <rule id="13ef8aa7-deb7-344c-6bf4-784f9ebaf414" name="Hit &amp; Run" hidden="false" book="BRB" page="38">
-                  <description>Take an Initiative test at the end of the assault phase, if succesful choose a direction and roll 3D6, move that far ignoring all models in base contact, if this would take you within 1&quot; of another unit stop 1&quot; away, treat all terrain as dangerous. The unit left makes an immediate D6&quot; consolidation. </description>
-                  <modifiers/>
-                </rule>
-                <rule id="13f7ece5-7450-1182-aae3-6ff0c19ad89c" name="Skilled Rider" hidden="false" book="BRB" page="41">
-                  <description>Automatically passes Dangerous Terrain and recieves +1 to Jink saves</description>
-                  <modifiers/>
-                </rule>
-                <rule id="1d556c1d-09d7-9910-e2fc-3704247307de" name="Independant Character" hidden="false" book="BRB" page="0">
-                  <description>Independent Characters can join and leave other non-vehicle non-&apos;loner&apos; units. Although Independent Characters may join with other Independent Characters to form a powerful multi-character unit.
-An Independent Character counts as having joined a unit if he ends his move within 2&quot; of them, if he is within 2&quot; of more than one unit you must declare which unit he is joining.
-An Independent Character may leave his unit and join another one in the same movement phase, but he may not join a unit in any other phase.
-An Independent Character cannot join or leave a unit that is locked in combat or falling back, he also may not leave a unit that has gone to ground.
-
-Look out Sir is taken on a 2+
-
-If a unit with an Independent Character in it has fallen to below 25% they test as if they had 25% remaning
-
-When an Independent Character joins a unit he looses all special rules that the unit does not have unless the rule says it applys to the unit (eg Stubborn) and vice versa
-
-If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Independent Character leaves the unit, he is still suffering from those effects as well, but they to not transfer to a new unit he joins.</description>
-                  <modifiers/>
-                </rule>
-                <rule id="975d3b38-5bdf-9d79-de1c-3000a1603a47" name="Scouts" hidden="false" book="BRB" page="41">
-                  <description>After all deployment but before first turn a unit with this rule may redeploy, if it is Infantry, Artillery, Walker or a Monstrous Creature it may redeploy anywhere within 6&quot;, all other unit types may redelpoy anywhere within 12&quot;.
-Any unit that redelpoys with this rule may not charge on the first turn.
-If held in reserve, the unit gains outflank.</description>
-                  <modifiers/>
-                </rule>
-              </rules>
+              <rules/>
               <profiles>
                 <profile id="5eea94be-2b1a-7739-cfb6-1e90391f083b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Sammael on Corvex" hidden="false" book="Codex: Dark Angels 6th" page="58">
                   <characteristics>
@@ -19167,7 +18969,20 @@ If held in reserve, the unit gains outflank.</description>
                   <modifiers/>
                 </profile>
               </profiles>
-              <links/>
+              <links>
+                <link id="8777d92c-f8a0-83f2-a5ce-6afdc7bceaaf" targetId="5d37847f-4c54-a134-0728-fa97a76e0fbc" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="9c88bfae-5545-9a1d-ea73-484b4d3d481b" targetId="cf6ef79b-8fdc-9eec-ba81-1003561684f6" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="1e0424fc-44a7-26f3-5a57-714e6b57a46f" targetId="093fc456-1d4f-01fb-c223-132bc01fe497" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="4951def6-a169-09bd-5114-53d229468d30" targetId="153beb27-ddea-bb1d-d61e-9dd5b1771124" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
             </entry>
           </entries>
           <entryGroups/>
@@ -19183,7 +18998,11 @@ If held in reserve, the unit gains outflank.</description>
         </rule>
       </rules>
       <profiles/>
-      <links/>
+      <links>
+        <link id="f577ed0b-ee7c-f709-da79-58d90c196fd5" targetId="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="5af558a4-0018-0d65-639e-29f866867420" name="Scout Squad" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
       <entries>
@@ -21087,7 +20906,7 @@ A mindlocked unit may not voluntarily mov, shoot or charge.  A mindlocked unit m
               <modifiers/>
               <links/>
             </entryGroup>
-            <entryGroup id="c86b2d95-d1cc-8be8-564e-58c7a87f3ab0" name="Right Hand" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
+            <entryGroup id="c86b2d95-d1cc-8be8-564e-58c7a87f3ab0" name="Right Hand" defaultEntryId="7eeb4f43-f47a-4a3f-7eb9-5f4abb17d01a" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
               <entries>
                 <entry id="ff3ee0e6-d29b-5360-094f-d338fde83bf4" name="Storm Bolter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
                   <entries/>
@@ -21317,6 +21136,24 @@ A mindlocked unit may not voluntarily mov, shoot or charge.  A mindlocked unit m
                         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="x2"/>
                         <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
                         <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Specialist Weapon, Unwieldy"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links/>
+                </entry>
+                <entry id="7eeb4f43-f47a-4a3f-7eb9-5f4abb17d01a" name="Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="56">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles>
+                    <profile id="ae3e3420-78cc-4d91-678e-1ff848c6e13b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Bolter" hidden="false" book="BRB" page="56">
+                      <characteristics>
+                        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+                        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+                        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Rapid Fire"/>
                       </characteristics>
                       <modifiers/>
                     </profile>
@@ -24342,7 +24179,7 @@ If the test is failed then the unit has it&apos;s WS reduced to 1 for the remain
 Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are immune to this rule.</description>
       <modifiers/>
     </rule>
-    <rule id="e44b8d08-ba96-44e9-e90e-7db14cf4d747" name="Fearless" hidden="false" book="BRB" page="35">
+    <rule id="e44b8d08-ba96-44e9-e90e-7db14cf4d747" name="Fearless" hidden="false" book="BRB" page="163">
       <description>Automatically pass all LD tests but cannot go to ground or use the &quot;Our Weapons Are Usless&quot; rule.</description>
       <modifiers/>
     </rule>
@@ -24354,7 +24191,7 @@ Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are 
       <description>Any model with the Inner Circle rule that is in base contact with a two models with this rule gain +1 Toughness</description>
       <modifiers/>
     </rule>
-    <rule id="477000f9-799b-8cdf-1ff3-d443b76bdb5a" name="Grim Resolve" hidden="false" book="Codex: Dark Angels 6th" page="28">
+    <rule id="477000f9-799b-8cdf-1ff3-d443b76bdb5a" name="Grim Resolve (Stubborn)" hidden="false" book="Codex: Dark Angels 6th" page="28">
       <description>A model with this rule has Stubborn and so ignores negative Leadership modifiers (BRB p172). In addition they may never choose to fail a morale check.</description>
       <modifiers/>
     </rule>
@@ -24370,8 +24207,8 @@ Models with &quot;And They Shal Know No Fear&quot; and &quot;Fearless&quot; are 
       <description>Take an Initiative test at the end of the assault phase, if succesful choose a direction and roll 3D6, move that far ignoring all models in base contact, if this would take you within 1&quot; of another unit stop 1&quot; away, treat all terrain as dangerous. The unit left makes an immediate D6&quot; consolidation. </description>
       <modifiers/>
     </rule>
-    <rule id="08f41b0c-b88d-03ba-8f39-c1f595a028c9" name="Icon of Old Caliban" hidden="false" page="0">
-      <description>Friendly Dark Angels within 12&quot; add 1 to their combat resolution</description>
+    <rule id="08f41b0c-b88d-03ba-8f39-c1f595a028c9" name="Icon of Old Caliban" hidden="false" page="49">
+      <description>Friendly Dark Angels within 12&quot; add 1 to their combat resolution.</description>
       <modifiers/>
     </rule>
     <rule id="cf6ef79b-8fdc-9eec-ba81-1003561684f6" name="Independant Character" hidden="false" book="BRB" page="166">
@@ -24393,8 +24230,9 @@ If the unit is suffering from ongoing effects (eg blind, soul blaze) and the Ind
       <description>Deployed after all other units anywhere &gt; 12&quot; away from enemy and outside their line of sight, or &gt; 18&quot; away within LoS.  Cannot charge in first turn after deploying this way.  Also has Outflank.</description>
       <modifiers/>
     </rule>
-    <rule id="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" name="Inner Circle" hidden="false" book="Codex: Dark Angels 6th" page="28">
-      <description>Fearless and Preferred Enemy (Chaos Space Marines)</description>
+    <rule id="b7935c72-7cf3-4d1a-ec27-1e158f6e7d44" name="Inner Circle (Fearless, Preferred Enemy (CSM))" hidden="false" book="Codex: Dark Angels 6th" page="28">
+      <description>Fearless: never fail Pinning, Fear, Regroup, or Morale checks, and cannot Go To Ground (BRB p163)
+and Preferred Enemy (Chaos Space Marines): Re-roll failed results of 1 for To Hit and To Wound rolls, in both close combat and shooting (BRB p169)</description>
       <modifiers/>
     </rule>
     <rule id="73499c50-3b77-f209-0f59-110947277010" name="Mindlock" hidden="false" book="Codex: Dark Angels 6th" page="32">
@@ -24445,7 +24283,7 @@ If held in reserve, the unit gains outflank.</description>
       <description>The Darkshroud has Shrouded Special Rule and all friendlies within 6&quot; have stealth</description>
       <modifiers/>
     </rule>
-    <rule id="e307c853-e9b2-c17c-b4a4-ceafc1ebb146" name="Shrouded" hidden="false" page="0">
+    <rule id="e307c853-e9b2-c17c-b4a4-ceafc1ebb146" name="Shrouded" hidden="false" book="BRB" page="170">
       <description>Counts it&apos;s cover save as 2 better than normal (Combines with Stealth)</description>
       <modifiers/>
     </rule>
@@ -24457,7 +24295,7 @@ If held in reserve, the unit gains outflank.</description>
       <description>A single model may fire at a different target before the rest of the unit.</description>
       <modifiers/>
     </rule>
-    <rule id="5d203f23-635e-275e-1aef-4a42b8691464" name="Stealth" hidden="false" page="0">
+    <rule id="5d203f23-635e-275e-1aef-4a42b8691464" name="Stealth" hidden="false" book="BRB" page="172">
       <description>Counts it&apos;s coversave as 1 point better than normal, (Combines with Shrouded)</description>
       <modifiers/>
     </rule>
@@ -24475,6 +24313,14 @@ If held in reserve, the unit gains outflank.</description>
     </rule>
     <rule id="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" name="Zealot" hidden="false" book="BRB" page="174">
       <description>Unit this Character is joined to has Fearless and Hatred (Everything)</description>
+      <modifiers/>
+    </rule>
+    <rule id="8dbde421-6cc8-72aa-0ec2-fc999e6f4dba" name="Precision Strikes" hidden="false" book="BRB" page="169">
+      <description>Melee hit rolls of 6 become Precision Strikes and may be allocated to an engaged model of your choice. (Look Out, Sir is still allowed.)</description>
+      <modifiers/>
+    </rule>
+    <rule id="2de4b722-e518-092c-7cb0-e88333e9eee3" name="Precision Shots" hidden="false" book="BRB" page="169">
+      <description>Shooting rolls of 6 become Precision Shots and may be allocated to an engaged model of your choice within range and line of sight. (No snap shots; Look Out, Sir is still allowed.)</description>
       <modifiers/>
     </rule>
   </sharedRules>

--- a/Dark Angels - Codex.cat
+++ b/Dark Angels - Codex.cat
@@ -6408,7 +6408,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
                 </entry>
               </entries>
               <entryGroups>
-                <entryGroup id="819a6589-2df0-f54b-0f56-27c68eea0e7c" name="Weapon" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
+                <entryGroup id="819a6589-2df0-f54b-0f56-27c68eea0e7c" name="Weapon" defaultEntryId="2454a76a-3ccc-ca9b-5cb6-ae8da19a39a9" minSelections="1" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
                   <entries>
                     <entry id="2454a76a-3ccc-ca9b-5cb6-ae8da19a39a9" name="Storm Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
                       <entries/>
@@ -6842,7 +6842,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
                   </profiles>
                   <links/>
                 </entry>
-                <entry id="47ea8d4a-db83-07bd-5538-6d3976c7b2a1" name="Pair of Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="60">
+                <entry id="47ea8d4a-db83-07bd-5538-6d3976c7b2a1" name="Pair of Lightning Claw" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" book="BRB" page="60">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
@@ -6882,7 +6882,7 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
               </modifiers>
               <links/>
             </entryGroup>
-            <entryGroup id="d3125817-89e2-4d10-c678-8bd3429e500e" name="Assault Weapons" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
+            <entryGroup id="d3125817-89e2-4d10-c678-8bd3429e500e" name="Special Weapons" minSelections="0" maxSelections="0" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
               <entries>
                 <entry id="e0c8a078-a245-e2c1-b058-9cd424b88045" name="Flamer" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false" page="0">
                   <entries/>
@@ -6940,7 +6940,12 @@ Immediatly after determining Warlord Traits, tell your opponent which units are 
                 </entry>
               </entries>
               <entryGroups/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="58153ee2-b9b6-32e2-1703-e69210584fd9" incrementChildId="7fed39dc-4eab-6fae-389b-d7935b0ec9ee" incrementField="selections" incrementValue="5.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <links/>
             </entryGroup>
             <entryGroup id="90394970-c80e-fcc3-f96c-b02706c8a48c" name="Exchange for" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minInRoster="0" maxInRoster="-1" collective="false" hidden="false">
@@ -24253,6 +24258,14 @@ A mindlocked unit may not voluntarily mov, shoot or charge.  A mindlocked unit m
       <description>So long as the vehicle dosen&apos;t move flat out or pop smoke, it may fire an additional weapon than normal and may fire at a different target.</description>
       <modifiers/>
     </rule>
+    <rule id="2de4b722-e518-092c-7cb0-e88333e9eee3" name="Precision Shots" hidden="false" book="BRB" page="169">
+      <description>Shooting rolls of 6 become Precision Shots and may be allocated to an engaged model of your choice within range and line of sight. (No snap shots; Look Out, Sir is still allowed.)</description>
+      <modifiers/>
+    </rule>
+    <rule id="8dbde421-6cc8-72aa-0ec2-fc999e6f4dba" name="Precision Strikes" hidden="false" book="BRB" page="169">
+      <description>Melee hit rolls of 6 become Precision Strikes and may be allocated to an engaged model of your choice. (Look Out, Sir is still allowed.)</description>
+      <modifiers/>
+    </rule>
     <rule id="7efe725d-80ba-52f2-0b7a-3ac65b79e496" name="Preferred Enemy (Chaos Space Marines)" hidden="false" book="BRB" page="169">
       <description>Reroll all failed to hit and to wound rolls of 1 against the chosen enemy in both shooting and assault.</description>
       <modifiers/>
@@ -24313,14 +24326,6 @@ If held in reserve, the unit gains outflank.</description>
     </rule>
     <rule id="610ff1cd-1978-12cb-d0ce-29ca4dc5da1f" name="Zealot" hidden="false" book="BRB" page="174">
       <description>Unit this Character is joined to has Fearless and Hatred (Everything)</description>
-      <modifiers/>
-    </rule>
-    <rule id="8dbde421-6cc8-72aa-0ec2-fc999e6f4dba" name="Precision Strikes" hidden="false" book="BRB" page="169">
-      <description>Melee hit rolls of 6 become Precision Strikes and may be allocated to an engaged model of your choice. (Look Out, Sir is still allowed.)</description>
-      <modifiers/>
-    </rule>
-    <rule id="2de4b722-e518-092c-7cb0-e88333e9eee3" name="Precision Shots" hidden="false" book="BRB" page="169">
-      <description>Shooting rolls of 6 become Precision Shots and may be allocated to an engaged model of your choice within range and line of sight. (No snap shots; Look Out, Sir is still allowed.)</description>
       <modifiers/>
     </rule>
   </sharedRules>


### PR DESCRIPTION
Also begin the long work of linking to Shared Rules from entries.
Also increment revision number to v36.
Also add default weapons for Assault Squad Sergeant.
Also add missing special rules for Scout Squads.

I'm just learning the rules, so this will help.  Not all entries' rules have been replaced by links, but most have.

Is this replacing rules with links to shared rules appropriate?
