### PR TITLE
CSM Legacies of Ruin for rhinos

### DIFF
--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="88" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="89" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="e04e4fdc-f3f4-b49a-79ac-b87f3e31d401" name="[FW] Arkos the Faithless (IA: Apoc 2013)" points="130.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA Apoc 2013" page="153">
       <entries>
@@ -23058,6 +23058,9 @@ Curse: Roll to hit as per normal againt one enemy vehicle within 18&quot;. If su
         <link id="ec63af4f-a129-155f-6885-12259b3cb03d" targetId="767879b7-ee12-d3c5-5523-498a308a5850" linkType="entry group">
           <modifiers/>
         </link>
+        <link id="46d99cee-c043-dbbd-b1d2-67a425a51c1d" targetId="9be57471-9796-716e-1145-bd67dedf8425" linkType="entry group">
+          <modifiers/>
+        </link>
       </links>
     </entry>
     <entry id="ec5d28a5-45ee-3773-9ddb-3dfc4a77b0d7" name="Dimensional Key" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -23896,6 +23899,12 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
         <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
             <condition parentId="roster" childId="3dd1fae4-8af3-bcef-9a8b-7acdc3aa9986" field="selections" type="at least" value="1.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="direct parent" childId="09243f44-531e-9560-4eee-88482d38ddbe" field="selections" type="equal to" value="1.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="89" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="90" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="e04e4fdc-f3f4-b49a-79ac-b87f3e31d401" name="[FW] Arkos the Faithless (IA: Apoc 2013)" points="130.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA Apoc 2013" page="153">
       <entries>
@@ -12562,7 +12562,11 @@ The unit must immediately disembark their transport before turning into the spaw
               <modifiers/>
               <rules/>
               <profiles/>
-              <links/>
+              <links>
+                <link id="5e1a7969-822d-7423-3946-698ddf5178ec" targetId="555984b7-f596-aa5d-79e1-1123f78ac454" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
             </entry>
           </entries>
           <entryGroups/>
@@ -12997,7 +13001,14 @@ The unit must immediately disembark their transport before turning into the spaw
       <profiles/>
       <links>
         <link id="6ac22f0a-2094-685c-4e19-a0b0d0a18e24" targetId="e4a96746-d9fc-bfb0-58fd-13fd3e3279f4" linkType="profile">
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+/5++" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="a804cf7c-7162-4211-86d5-5cf48d7855f1" childId="c77cfec6-0979-42dc-23ae-979d92f00507" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
         <link id="f239a13c-9c2e-3b6f-05de-f6aaca18039f" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
           <modifiers/>
@@ -21353,7 +21364,11 @@ At the beginning of each turn, roll a D3 (consulting the table in Hurons profile
               <modifiers/>
               <rules/>
               <profiles/>
-              <links/>
+              <links>
+                <link id="94b1fdbd-5226-5e8e-0545-925f53a22c04" targetId="555984b7-f596-aa5d-79e1-1123f78ac454" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
             </entry>
           </entries>
           <entryGroups/>
@@ -21814,7 +21829,7 @@ At the beginning of each turn, roll a D3 (consulting the table in Hurons profile
             </modifier>
             <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="1425fc4e-63d3-4fba-ba76-de4d5cfc72e7" childId="b7e3670c-b426-eb60-e07f-9918bcd607d2" field="selections" type="less than" value="1.0"/>
+                <condition parentId="1425fc4e-63d3-4fba-ba76-de4d5cfc72e7" childId="b7e3670c-b426-eb60-e07f-9918bcd607d2" field="selections" type="at least" value="1.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -21916,7 +21931,7 @@ At the beginning of each turn, roll a D3 (consulting the table in Hurons profile
           <modifiers>
             <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="1425fc4e-63d3-4fba-ba76-de4d5cfc72e7" childId="1d2f6f69-0227-da85-1e25-c8b1334dcb96" field="selections" type="at least" value="1.0"/>
+                <condition parentId="1425fc4e-63d3-4fba-ba76-de4d5cfc72e7" childId="b7e3670c-b426-eb60-e07f-9918bcd607d2" field="selections" type="at least" value="1.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -21954,7 +21969,14 @@ At the beginning of each turn, roll a D3 (consulting the table in Hurons profile
           <modifiers/>
         </link>
         <link id="e9469a69-9961-a800-a51b-05d3fa9f6059" targetId="0dc7d750-fac9-1d04-f3c7-edb7ebd31f8a" linkType="profile">
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+/5++" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="1425fc4e-63d3-4fba-ba76-de4d5cfc72e7" childId="b7e3670c-b426-eb60-e07f-9918bcd607d2" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
         <link id="be701fd0-67de-de18-2a3b-a6f36d1154c0" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
           <modifiers/>
@@ -25781,6 +25803,12 @@ Codex: Grey Knights
     <profile id="39727fe9-2186-da1f-121a-ba156ae612eb" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Warpflame Gargoyles" hidden="false">
       <characteristics>
         <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="All weapons on the Vehicle have Soul Blaze"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="555984b7-f596-aa5d-79e1-1123f78ac454" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Terminator Armour" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="2+/5++, have the Bulky, Deep Strike, Relentless special rules, and may not make sweeping advances."/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
Added Legacies of Ruin to Chaos Rhinos.
Fixed Daemonic Possession conflicting with legacies on shared entry for
Chaos Vehicle Equipment.
