### PR TITLE
Sporocyte/Mucolid and Tyrannocyte

### DIFF
--- a/Tyranids - Codex.cat
+++ b/Tyranids - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f2f40acf-4ce2-862a-6856-dcb472106abb" revision="24" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Tyranids: Codex (2014)" authorName="Spartacusbob/ Randobar / Arnestig" authorContact="" authorUrl="http://catalogue.randomhit.org/viewtopic.php?f=5&amp;t=380" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f2f40acf-4ce2-862a-6856-dcb472106abb" revision="25" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.14b" name="Tyranids: Codex (2014)" authorName="Spartacusbob/ Randobar / Arnestig" authorContact="" authorUrl="http://catalogue.randomhit.org/viewtopic.php?f=5&amp;t=380" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="ec0f9ad2-131d-f270-4ea6-b92ea3e4c4e0" name="Barbed Hierodule" points="565.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="IA4 - 2nd">
       <entries>
@@ -28,18 +28,7 @@
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="e09777b5-4900-b5ba-61c5-cfa629929e92" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="c3b5c78f-7105-b97a-a4e8-0d80f95ce175" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles>
@@ -706,18 +695,7 @@ Wound rolls of 1 in the Shooting phase.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="61af8b07-55a6-5740-5804-7360a8d12ca9" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="eef61639-1a51-f4ae-08ef-212752b290a3" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -1248,18 +1226,7 @@ Wound rolls of 1 in the Shooting phase.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="5e8a2197-1578-9914-eacb-2d88e31d6b40" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f8b4c451-114e-9dee-6ec6-351894f5e829" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -1693,18 +1660,7 @@ Wound rolls of 1 in the Shooting phase.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="a72b0202-6021-70c6-9fec-563355d9e82e" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="588eeec0-6700-d2c6-f8af-183ca56141b4" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="18dd615f-10a7-5ae5-4faf-70b4c506f505" name="&quot;It&apos;s after me!&quot;" hidden="false" book="Codex: Tyranids" page="61">
@@ -2088,18 +2044,7 @@ This attack automatically hits and may only be used to non-Extremely Bulky Infan
           <links/>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="466e87de-bfcc-cee5-49be-20d2a3c4a0e6" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2ffddf6b-11f6-d921-d6b8-1b6100104204" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="9a42d7dc-6661-61b0-06d6-4f14665991a0" name="Rampage" hidden="false">
@@ -3342,18 +3287,7 @@ Assault: Gains HoW with +1S and Strikedown-USR.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="c66b8f77-b93b-c43e-2b1f-0ae763567603" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="88cd1c39-c7bc-2c10-9309-e219a731aeb4" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="586331bc-4680-2a1f-6158-256a67b901ba" name="Symbiotic Targeting" hidden="false" book="Codex: Tyranids" page="50">
@@ -3841,18 +3775,7 @@ during the same turn that it uses this special rule.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="20fb0dea-dc1f-0fba-e32a-1dc3062b3dc9" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ece27374-31a1-a4b4-fda4-86484fdafa66" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -4021,18 +3944,7 @@ during the same turn that it uses this special rule.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="baea9e68-91b1-1b4d-c4e3-17e62f4794d3" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="06828c14-e0ee-4995-5c1c-fb49fdbec6da" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -4096,16 +4008,6 @@ during the same turn that it uses this special rule.</description>
           <entryGroups/>
           <modifiers/>
           <links/>
-        </entryGroup>
-        <entryGroup id="5112afba-7355-aae2-ec63-80c18f8cb1a8" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="650c8488-0a8b-d717-c29b-9b1866aca806" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
@@ -4428,18 +4330,7 @@ suffer -5 to their Initiative
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="6db9ea97-b8d7-2dd3-49c4-525b7d1fccd6" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6f30d57d-5fdc-a666-9b2f-28c090162aaa" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="a5f71c57-8468-5994-b782-4acc19773c1f" name="Feeder-beast" hidden="false" book="Codex: Tyranids" page="51">
@@ -4745,18 +4636,7 @@ not benefit from this rule.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="e22bcb0f-4ce0-807b-e3c8-c2c5d3053ea5" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="0caa785f-ef95-d03b-3d3c-adb3b9aaaa38" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="cad035e0-3ada-86ab-72f2-a2f5644f9282" name="Raking Strike" hidden="false" book="Codex: Tyranids" page="56">
@@ -4884,18 +4764,7 @@ not benefit from this rule.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="dd49ea7b-237b-0efa-c090-2b6422c716f4" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="299c82b4-2186-6fdd-de05-7979c5d607bc" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -5194,16 +5063,6 @@ not benefit from this rule.</description>
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="edbc29d0-7405-3962-4575-88dc35bdefc8" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="de9014ac-5a64-462a-ac11-5a29666c35f8" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -5322,18 +5181,7 @@ normally be D6+3&quot;).</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="edc707c0-b914-ae8a-b568-99aa050cffc6" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="96719f2f-9372-e701-430b-fc1e9367a3ad" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -7416,18 +7264,7 @@ normally be D6+3&quot;).</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="09a54a31-22be-085f-70fe-c449bcbb1f4f" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2a2370be-683e-a3cd-196d-a7849fe5c840" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -11254,18 +11091,7 @@ Leviathan II).</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="9e3d12c0-82f3-fe85-6135-6818ff2b1f95" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ae6d7fb5-cd75-7ab4-a59d-002c1534a4a9" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -11310,18 +11136,7 @@ Leviathan II).</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="be0c4147-d4b0-b1ef-0627-2a50377f7cb1" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8bb022ce-10f8-508c-2104-b1df7247dac7" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="706a82b8-838f-3642-ae19-99a025fc8590" name="Psychic Barrier" hidden="false">
@@ -11576,16 +11391,6 @@ Leviathan II).</description>
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="911e79c8-9a20-e5c6-6a03-93ae8c2b1c3e" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="43757ee1-a336-0cc3-cf50-7092f9d97746" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules>
@@ -11721,18 +11526,7 @@ Afterwards, remove all Spores from the game.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="da2cfc9b-a44f-40bf-8346-ed4ec09aec36" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="01a8f9ae-72e8-ca7d-6542-228fc753fb2b" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -11789,18 +11583,7 @@ Afterwards, remove all Spores from the game.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="45f938f5-99eb-a512-9b87-a611a3d6f1be" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="07f17bff-0536-250e-a37f-44b6b1a60c98" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="aceb454f-c92e-fda6-c9b6-18975579b552" name="Alpha Leader" hidden="false" book="Codex: Tyranids" page="60">
@@ -11929,18 +11712,7 @@ Strength 3 AP- hit for each model (excluding Pyrovores) within D6&quot; of the s
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="4eaa485d-bddf-2480-aa11-27922d63a61b" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="38f26d8b-c60c-c266-c8eb-ccd4429e2012" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -12143,18 +11915,7 @@ normally.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="11f39611-fed0-50bb-f1f0-30ce576179c6" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="56d1e8b3-9092-34fc-84c4-7d6aadc041f7" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -12246,18 +12007,7 @@ normally.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="d7733153-ab88-0e8e-b80d-ad44d1e084dc" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1efca622-d4a1-fd5b-cd0f-d8c2df2a3e6b" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -12290,18 +12040,7 @@ normally.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="e5262d62-e3f6-cdd9-47ff-646e678b7416" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1bcca1f3-6691-0d96-47a3-c2703c77a5e1" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles>
@@ -12401,18 +12140,7 @@ normally.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="e91b5c79-8476-df12-71e2-4cf6bede8d11" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="cd607826-b30c-7aec-443e-ab0e02a25849" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -13509,18 +13237,7 @@ If this destroys a wall section, remove it completely if possible.</description>
           <links/>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="1fb915a6-65be-6b99-d02a-4b63c2ff092c" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4b868e59-dda4-2fca-0921-0b32a6533158" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -14530,7 +14247,6 @@ The Formation’s Trygon and Mawloc enter play via Deep Strike as usual.</descri
           <modifiers/>
         </rule>
         <rule id="a70f968f-b3d6-f9e7-cc81-d44265b9b7c2" name="Coordinated Attack" hidden="false" book="Apocalypse" page="165">
-          <description></description>
           <modifiers/>
         </rule>
       </rules>
@@ -15240,16 +14956,6 @@ The Formation’s Trygon and Mawloc enter play via Deep Strike as usual.</descri
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="c66df922-0694-cb99-d852-7b6446e16561" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9c1638f5-e6e4-1406-4afb-b883a7c2233e" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -15341,16 +15047,6 @@ The Formation’s Trygon and Mawloc enter play via Deep Strike as usual.</descri
           <entryGroups/>
           <modifiers/>
           <links/>
-        </entryGroup>
-        <entryGroup id="17a7bd19-ccab-62ba-5271-b56a0f9080b6" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="cb18e2dc-ce32-0332-49b5-8792650a1f2a" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
@@ -15471,16 +15167,6 @@ The Formation’s Trygon and Mawloc enter play via Deep Strike as usual.</descri
           <entryGroups/>
           <modifiers/>
           <links/>
-        </entryGroup>
-        <entryGroup id="df0e9810-cd85-a419-aa0e-9a05356568a7" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="528e978a-c848-1413-3067-9427e54c5237" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
@@ -16349,18 +16035,7 @@ The Formation’s Trygon and Mawloc enter play via Deep Strike as usual.</descri
           <links/>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="ea93cc49-ddff-b023-82d1-05bd860dda35" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d14a5649-0895-2457-34c6-761ad380449a" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="538150a7-702a-de06-7cf9-c667b16fe848" name="Alien Cunning" hidden="false" book="Codex: Tyranids" page="59">
@@ -16467,18 +16142,7 @@ chosen unit has that special rule until the end of the turn.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="42edd96b-3968-4554-b028-6aca26affb07" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7c3446a9-cce3-06c7-b2e0-ffb30f005a38" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules>
         <rule id="74009769-8f8c-e881-e48d-201685cd661a" name="Hypertoxic" hidden="false">
@@ -16582,16 +16246,6 @@ chosen unit has that special rule until the end of the turn.</description>
           <entryGroups/>
           <modifiers/>
           <links/>
-        </entryGroup>
-        <entryGroup id="fc8f042d-0aa1-d159-895f-76ef3f631d39" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="c1c6161e-6bc5-05fc-4888-82bd431f7c0b" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
@@ -16698,16 +16352,6 @@ chosen unit has that special rule until the end of the turn.</description>
           <entryGroups/>
           <modifiers/>
           <links/>
-        </entryGroup>
-        <entryGroup id="9ec2400f-8310-4828-f053-62f7543b0371" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3639dbdc-a6a3-8821-b95d-67777af9300b" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
@@ -17144,16 +16788,6 @@ own, unless their own would be higher for any reason.</description>
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="3715de71-5d99-f454-f393-33f7da3cd5d7" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f3a0d4ca-49fa-e27d-55ad-d172200fdfb5" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -17377,16 +17011,6 @@ own, unless their own would be higher for any reason.</description>
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="853297fd-0d7f-f91c-1937-622179a523c1" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9fab903e-04bf-e0b7-1425-0e949cf82949" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -17469,16 +17093,6 @@ own, unless their own would be higher for any reason.</description>
           <entryGroups/>
           <modifiers/>
           <links/>
-        </entryGroup>
-        <entryGroup id="45006cd4-ae95-37e8-90a5-07176c7d2fa0" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="66fb4401-c8aa-a806-8dc6-234577d6523e" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
@@ -17864,18 +17478,7 @@ rolls.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="c68fe810-5dd7-c6da-8237-9f2184c219d2" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="81ae95d6-5af9-4749-444e-d4afd41205fa" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -18877,18 +18480,7 @@ Venomthrope have the Shrouded special rule.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="a6909a44-826c-e7c9-4aad-f929cf2bd178" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ff69fea9-70b8-0b5c-21db-76c6d544eab0" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -19321,64 +18913,49 @@ random, non-character model in the unit, if there is no character (or he is dead
           </links>
         </entry>
       </entries>
-      <entryGroups>
-        <entryGroup id="0e15f37b-2be2-4e47-9073-c73a1cf77080" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d224cd55-3d72-9cfe-ba5c-030f116d52d3" targetId="c1f3dbf4-3067-f880-0073-cba8050ccda2" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
       <links/>
     </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="c1f3dbf4-3067-f880-0073-cba8050ccda2" name="Tyrannocyte" points="75.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entry id="04081d69-0593-fc1d-0cf0-5453fd3f6584" name="Tyrannocyte" points="75.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
       <entryGroups>
-        <entryGroup id="847b2f5e-b036-a0eb-1c4c-206408b1e1b7" name="Must choose one of the following weapons:" defaultEntryId="b0a70952-4acf-0167-dc7b-bffc94279b4b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="e5197fd8-f2f0-03c4-3b57-b6f1a87e1f4e" name="Must choose one of the following weapons:" defaultEntryId="d9e6d9f8-9ca4-bb12-0d2a-57612ffbda90" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="29fb7b71-ef88-3f20-a672-3e0cb9918064" name="5x Barbed strangler" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="42dee30c-64bf-ba43-f9fa-90ca60341f96" name="5x Barbed strangler" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="c9b4161b-a24e-9bbd-31d2-89844d73c71f" targetId="f66ca200-d073-01c3-2ae8-59eb5854be00" linkType="profile">
+                <link id="9de2b6c9-2afa-30e8-f63f-c0d4d9d19845" targetId="f66ca200-d073-01c3-2ae8-59eb5854be00" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
             </entry>
-            <entry id="b0a70952-4acf-0167-dc7b-bffc94279b4b" name="5x Deathspitters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="d9e6d9f8-9ca4-bb12-0d2a-57612ffbda90" name="5x Deathspitters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="2c97c2c5-27af-2c13-f1fd-b8b405e34e79" targetId="83d9afba-635d-db55-d4e7-1a8eab996b12" linkType="profile">
+                <link id="47d922e8-0ed9-788e-e191-24a269e00ba0" targetId="83d9afba-635d-db55-d4e7-1a8eab996b12" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
             </entry>
-            <entry id="d8d7a1e8-8923-986a-213f-86c6a5537cd1" name="5x Venom Cannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="90c53092-3ce6-b8ff-734a-b02b1386d231" name="5x Venom Cannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="c0943170-d4ca-03dd-c450-97f742ea053a" targetId="27480ef3-cdf1-f258-4f1c-0cb4af372b58" linkType="profile">
+                <link id="01c504d9-2156-b83c-375e-197167227d35" targetId="27480ef3-cdf1-f258-4f1c-0cb4af372b58" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
@@ -19392,7 +18969,7 @@ random, non-character model in the unit, if there is no character (or he is dead
       <modifiers/>
       <rules/>
       <profiles>
-        <profile id="9ee48280-2113-d4d1-ab45-4333849dbea1" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Tyrannocyte" hidden="false" page="0">
+        <profile id="17231ef8-9182-37b0-6c88-f2f8d12e02e9" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Tyrannocyte" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
             <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
@@ -19409,24 +18986,150 @@ random, non-character model in the unit, if there is no character (or he is dead
         </profile>
       </profiles>
       <links>
-        <link id="da7e95a1-ee5e-16c5-1c05-32ee297cf3dc" targetId="0c733e93-7ddf-142b-5eaf-7c0448dfada5" linkType="rule">
+        <link id="0d8e2532-611c-f4ed-ee19-93b7aa70d194" targetId="0c733e93-7ddf-142b-5eaf-7c0448dfada5" linkType="rule">
           <modifiers/>
         </link>
-        <link id="6ad7c2c7-62a3-9fae-ebc7-e26a90a6c1e6" targetId="47496344-bcf6-1216-a146-2af89ffca024" linkType="rule">
+        <link id="adbb690c-35d6-4ed0-09af-98aabe3a9ed4" targetId="47496344-bcf6-1216-a146-2af89ffca024" linkType="rule">
           <modifiers/>
         </link>
-        <link id="4d2e0d5e-6d4e-7e31-0c09-b306f265d94f" targetId="44d1e26e-edf6-7f5e-c0f4-8759aa455e27" linkType="rule">
+        <link id="447c3658-e778-d75f-9683-7bd21e2fb485" targetId="44d1e26e-edf6-7f5e-c0f4-8759aa455e27" linkType="rule">
           <modifiers/>
         </link>
-        <link id="727e9564-19b8-9094-deb8-8eed8adb7de7" targetId="df193096-f043-32d5-c3ea-47959c56e10d" linkType="rule">
+        <link id="b0d3315a-9c37-31ed-1242-0cbeee7053ee" targetId="df193096-f043-32d5-c3ea-47959c56e10d" linkType="rule">
           <modifiers/>
         </link>
-        <link id="01bac449-641d-2748-506e-cd25e1cb1c11" targetId="be993f25-3873-e26f-ba32-20c8e35f0618" linkType="rule">
+        <link id="3564b28d-ff50-28fe-6ec2-c28b1c6ce5e7" targetId="be993f25-3873-e26f-ba32-20c8e35f0618" linkType="rule">
           <modifiers/>
         </link>
       </links>
     </entry>
-  </sharedEntries>
+    <entry id="622b08fb-ba49-901e-f55e-e365252233e3" name="Mucolid Spore Cluster" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="White Dwarf 2014 #41">
+      <entries>
+        <entry id="4c6fbc97-4805-e7cb-1967-3ba796edf31b" name="Mucolid Spore" points="15.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="a475706b-be95-19ed-dde7-9f1d092c441c" targetId="be993f25-3873-e26f-ba32-20c8e35f0618" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="aeb20d4e-e605-d584-93cd-2a000ea1c7a3" targetId="18b954cd-f827-b45d-fb5b-b2ee38be97db" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="be9e9ac1-0e6e-0d48-60e6-be53611db54d" targetId="148bd9df-ab60-ca21-8976-7c77decb8053" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="adb452cb-3139-3510-e2a6-07de135bef99" targetId="4df4ddaf-df7c-6901-5a52-311de09e7b39" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="a97ada36-d066-6d1f-d751-b9a9dfc27bc8" targetId="44d1e26e-edf6-7f5e-c0f4-8759aa455e27" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="2094c9d1-2f78-c794-529b-35af7d0e8694" targetId="81015637-1c4d-77e2-0b82-b2cfe6847c5f" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="a6f61e58-ffc1-e426-3133-51ffa546b4ce" name="Sporocyst" points="75.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="69560f92-14fb-7ce5-66fa-9d5534fe4f99" name="Must choose one of the following weapons:" defaultEntryId="caa14506-5058-4f4d-7236-459a0c8997c0" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="1b6beaef-40c7-e482-9d2f-b22e2ba7b167" name="5x Barbed strangler" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="22060c5a-52df-33b8-4074-ac87251f62e2" targetId="f66ca200-d073-01c3-2ae8-59eb5854be00" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="caa14506-5058-4f4d-7236-459a0c8997c0" name="5x Deathspitters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="a44bcaa8-29af-4979-cde1-a95ec29d9a6b" targetId="83d9afba-635d-db55-d4e7-1a8eab996b12" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="39a1efbb-e1dc-1c42-af0f-350854fbb09b" name="5x Venom Cannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="abbd24c5-a667-3ce4-78bf-9e91467ff8fd" targetId="27480ef3-cdf1-f258-4f1c-0cb4af372b58" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="f9875efe-f2c5-50c1-d20a-5ea5955225ef" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Sporocyst" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="2"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="6"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="53d47bbd-0e4d-9ef5-5f85-942b57b4048e" targetId="ec080480-ade1-4910-3d11-9acfd44ec0c4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5bbbd1c8-fea6-a19a-87de-d14c1c300e62" targetId="df193096-f043-32d5-c3ea-47959c56e10d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="25b2e501-4d3c-4cb9-6c2f-54d595c67e09" targetId="be993f25-3873-e26f-ba32-20c8e35f0618" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bf288ec8-b695-11e4-f732-f95c939b58d6" targetId="e80bfb56-3880-0414-faf4-03d68799e699" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a154ebbc-67ad-1b3b-2cfa-ada77fd2e510" targetId="12ba9eaa-dfeb-52bd-64ea-0a87e248c99f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6059f09a-44c2-2b4c-546a-a0be0b772bdb" targetId="52bd360d-19a2-5837-e640-c78dccba9936" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+  </entries>
+  <rules/>
+  <links/>
+  <sharedEntries/>
   <sharedEntryGroups>
     <entryGroup id="c6c4ac05-c1b7-88d3-4153-48657368082b" name="Bio-artifacts" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
@@ -19909,6 +19612,28 @@ Once a Tyrannocyte Deep Strikes the unit carried by it must disembark. Place the
       <description>Very Bulky models count as three models for the purposes of Transport Capacity.</description>
       <modifiers/>
     </rule>
+    <rule id="3acb8ce5-e194-2a5b-935b-02d51f5b1c28" name="Massive FLoating Bomb" hidden="false">
+      <description>Each Mucolid Spore uses the Floating Death and Living Bomb rules that apply to Spore Mines (see Codex: Tyranids). All references to Spore Mine and Spore Mine Clusters in these special rules apply to Mucolid Spores also, except that the hits inflicted when a Mucolid Spore explodes are Strength 8 AP3 rather than Strength 4 AP4. Increase the Strength of the attack for additional Mucolid Spores as for Spore Mines.</description>
+      <modifiers/>
+    </rule>
+    <rule id="9a57d478-678b-0bec-f030-d3a7c408e54b" name="Skyblast" hidden="false">
+      <description>Mucolid Spore Clusters are allowed to assault Zooming Flyers or Swooping Monstrous Flying Creatures. If they do so successfully then they will explode as described in the FLoating Death special rule, hitting the target automatically, with Strength and AP as described in &quot;Massive FLoating Bomb&quot; rule. Hits on Zooming Flyers are always resolved against the target model&apos;s side armour.</description>
+      <modifiers/>
+    </rule>
+    <rule id="e80bfb56-3880-0414-faf4-03d68799e699" name="Immobile Pod" hidden="false">
+      <description>A model with this special rule cannot move. It can never go to ground (voluntarily or otherwise) and cannot consolidate or make a sweeping advance.</description>
+      <modifiers/>
+    </rule>
+    <rule id="12ba9eaa-dfeb-52bd-64ea-0a87e248c99f" name="Psychic Resonator" hidden="false">
+      <description>Any friendly Synapse Creature within 6&quot; of this model adds 6&quot; to its synapse range.</description>
+      <modifiers/>
+    </rule>
+    <rule id="52bd360d-19a2-5837-e640-c78dccba9936" name="Spore node" hidden="false">
+      <description>A model with this special rule can produce a Spore Mine Cluster (see Codex: Tyranids) with three SPore Mines in the shooting phase, in addition to any attacks it makes. Place the Spore Mines wholly within 6&quot; of the model, in unit coherency and not in impassable terrain or within 1&quot; of an enemy model. After they are placed, the Spore Mines are treated as a separate unit for the rest of the battle.
+
+Once per battle, a Sporocyst can produce a single Mucolid Spore instead of a Spore Mine Cluster. This is placed in the same way as a Spore Mine Cluster.</description>
+      <modifiers/>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="5858d95c-32e4-fd1c-e4f3-3b7a5327dbf8" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Acid Blood" hidden="false" book="Codex: Tyranids" page="67">
@@ -20337,6 +20062,21 @@ Once a Tyrannocyte Deep Strikes the unit carried by it must disembark. Place the
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
         <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
         <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Blast"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="4df4ddaf-df7c-6901-5a52-311de09e7b39" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Mucolid Spore" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="-"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="-"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="1"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="-"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="3"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
- Added rules for Sporocyte and Mucolid Spore Cluster.
- Moved Tyrannocyte to No Forge Org slot instead to allow for a more
  easier selection of the pods.
