### PR TITLE
[CSM] Fixing multiple issues with Chaos Terminators (all 3 books)

### DIFF
--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="116" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="117" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="e04e4fdc-f3f4-b49a-79ac-b87f3e31d401" name="[FW] Arkos the Faithless (IA: Apoc 2013)" points="130.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA Apoc 2013" page="153">
       <entries>

--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -14267,133 +14267,145 @@ The unit must immediately disembark their transport before turning into the spaw
         </entry>
         <entry id="d11591d1-84c4-239c-7718-2351663067af" name="Terminator" points="31.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="4401dfb4-1119-7970-5a2f-85544fcf1845" name="Lightning Claw" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+		    <entry id="4401dfb4-1119-7970-5a2f-85544fcf1842" name="Replace all weapons w/ Pair of Lightning Claws" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="feee3354-8a87-1621-14bd-bc4d66e0fce5" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
+                <link id="caa09472-d1d4-8b38-8c16-d3a5b957b552" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
-            </entry>
-            <entry id="0ae4c849-0881-d972-5c1f-02833ec8b04c" name="Powerfist" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="b721945e-51d0-a341-a2fb-3d9edd7f9054" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="0bc15bda-f729-8842-c6ee-9f9f95af3f21" name="Chainfist" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="f26de7fd-3e76-7f75-cc3c-edf7369bf259" targetId="b9747458-fe08-1554-78ce-3b8e9034aab5" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="ffe5a40c-a074-04a8-c958-d21918229843" name="Combi weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="cc55afd3-487d-dc19-54d5-75a0406b57fe" targetId="e4d19ad2-1cb9-c9f4-0d63-3298483883ce" linkType="entry group">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="3d7c5802-8832-945f-19a7-cf70a145ef5d" name="Pair of Lightning Claws" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="46b2ed33-a031-c3ae-4692-33663732da8a" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="9ae05cca-c09b-dcde-4ec6-1678ed8eb8b7" name="Heavy Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="dddf61a4-9106-83f1-1ead-566040d507c1" name="Heavy Weapons" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-                  <entries>
-                    <entry id="f41c9dcb-f792-7e5b-88d5-8ed51514f1ba" name="Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links>
-                        <link id="8c8adb8e-03cd-b5d1-bc32-038b450a4f23" targetId="55d0de57-c29f-6976-8380-83dfd9524c36" linkType="profile">
-                          <modifiers/>
-                        </link>
-                      </links>
-                    </entry>
-                    <entry id="c4a5eeb9-1900-cc03-3850-c66f65f0fe21" name="Reaper Autocannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links>
-                        <link id="372e2871-ee83-df6f-21fb-80b5400fd5db" targetId="4302374c-8225-ec0f-b1ea-b4d8fed05e74" linkType="profile">
-                          <modifiers/>
-                        </link>
-                      </links>
-                    </entry>
-                  </entries>
-                  <entryGroups/>
-                  <modifiers>
-                    <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="d11591d1-84c4-239c-7718-2351663067af" field="selections" type="less than" value="4.0"/>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="5631ed90-a0df-fdda-0d93-d9a89f3c4152" field="selections" type="less than" value="1.0"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="increment" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="d11591d1-84c4-239c-7718-2351663067af" field="selections" type="equal to" value="9.0"/>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="5631ed90-a0df-fdda-0d93-d9a89f3c4152" field="selections" type="equal to" value="1.0"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <links/>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
             </entry>
           </entries>
-          <entryGroups/>
+          <entryGroups>
+			<entryGroup id="13a1400f-7099-9159-164f-10b3d913c892" name="Terminator CCW" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+			  <entries>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1845" name="Lightning Claw" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b554" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="0ae4c849-0881-d972-5c1f-02833ec8b04c" name="Powerfist" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="5da58c92-32fc-1b59-53b9-16b1f95bc97b" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="0bc15bda-f729-8842-c6ee-9f9f95af3f21" name="Chainfist" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="bb146222-560d-0e59-24aa-89e901af71c8" targetId="b9747458-fe08-1554-78ce-3b8e9034aab5" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="1a01a481-8c10-4a96-6d21-a44a15d09ad6" name="Power Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="3285198d-4e11-d9ba-8e69-997314abfece" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
+						  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+			  </entries>
+			  <entryGroups/>
+              <modifiers>
+				<modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+			  </modifiers>
+              <links/>
+			</entryGroup>
+		    <entryGroup id="13a1400f-7099-9159-164f-10b3d913c898" name="Terminator ranged weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+			  <entries>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1846" name="Combi-Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b551" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1823" name="Combi-Weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b566" targetId="e4d19ad2-1cb9-c9f4-0d63-3298483883ce" linkType="entry group">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+			  </entries>
+			  <entryGroups/>
+              <modifiers>
+				<modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+			  </modifiers>
+              <links/>
+			</entryGroup>
+		  </entryGroups>
           <modifiers/>
           <rules/>
           <profiles/>
@@ -14596,6 +14608,49 @@ The unit must immediately disembark their transport before turning into the spaw
         </entry>
       </entries>
       <entryGroups>
+		<entryGroup id="15de0774-d7f8-6f6c-869e-c5018665c12f" name="Heavy Weapons" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="f32bee92-9332-52ad-2743-d0877f8dce5c" name="Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b7a23867-5ca7-f6c7-d1bd-b768e6d88916" targetId="caf9fcec-d7c6-5e23-d9c7-043019f03a3f" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="def929bc-fddb-6277-f270-d23130932d02" name="Reaper Autocannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="6b44874b-a343-4a09-8ec0-96c4b07fe77c" targetId="78e1eda3-9f50-5c7a-7ef9-fa4724e5e6b9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers>
+			<modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="d11591d1-84c4-239c-7718-2351663067af" field="selections" type="at least" value="4.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+		  </modifiers>
+          <links/>
+        </entryGroup>
         <entryGroup id="eebf5134-3bff-b3e9-48a6-31c1fe7bb3b7" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>

--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -14648,6 +14648,17 @@ The unit must immediately disembark their transport before turning into the spaw
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+			<modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="d11591d1-84c4-239c-7718-2351663067af" field="selections" type="at least" value="9.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
 		  </modifiers>
           <links/>
         </entryGroup>

--- a/Chaos Space Marines - Supplement - Black Legion.cat
+++ b/Chaos Space Marines - Supplement - Black Legion.cat
@@ -3471,76 +3471,145 @@ If Abaddon is in the primary force, he must be the warlord.</description>
       <entries>
         <entry id="d11591d1-84c4-239c-7718-2351663067af" name="Terminator" points="34.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="4401dfb4-1119-7970-5a2f-85544fcf1845" name="Lightning Claw" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+		    <entry id="4401dfb4-1119-7970-5a2f-85544fcf1842" name="Replace all weapons w/ Pair of Lightning Claws" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="caa09472-d1d4-8b38-8c16-d3a5b957b554" targetId="8bc34c1b-4d62-57d1-a620-3f3f6c6f7fa9" linkType="profile">
+                <link id="caa09472-d1d4-8b38-8c16-d3a5b957b552" targetId="8bc34c1b-4d62-57d1-a620-3f3f6c6f7fa9" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
-            </entry>
-            <entry id="0ae4c849-0881-d972-5c1f-02833ec8b04c" name="Powerfist" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5da58c92-32fc-1b59-53b9-16b1f95bc97b" targetId="43d8c282-55da-e93a-8a76-6f876d802e39" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="0bc15bda-f729-8842-c6ee-9f9f95af3f21" name="Chainfist" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="bb146222-560d-0e59-24aa-89e901af71c8" targetId="dd5fa131-b87d-aeb0-9573-38dff71ed22f" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="ffe5a40c-a074-04a8-c958-d21918229843" name="Combi-Weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="efd0364e-7334-781a-fa9a-f1d1718e8b05" targetId="984c6378-04a8-4ae7-6636-cff4a77e639d" linkType="entry group">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="3d7c5802-8832-945f-19a7-cf70a145ef5d" name="Pair of Lightning Claws" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="41fcb9f4-e5c9-9d59-7b16-676cac7b4173" targetId="8bc34c1b-4d62-57d1-a620-3f3f6c6f7fa9" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="1a01a481-8c10-4a96-6d21-a44a15d09ad6" name="Heavy Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
             </entry>
           </entries>
-          <entryGroups/>
+          <entryGroups>
+			<entryGroup id="13a1400f-7099-9159-164f-10b3d913c892" name="Terminator CCW" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+			  <entries>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1845" name="Lightning Claw" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b554" targetId="8bc34c1b-4d62-57d1-a620-3f3f6c6f7fa9" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="0ae4c849-0881-d972-5c1f-02833ec8b04c" name="Powerfist" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="5da58c92-32fc-1b59-53b9-16b1f95bc97b" targetId="43d8c282-55da-e93a-8a76-6f876d802e39" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="0bc15bda-f729-8842-c6ee-9f9f95af3f21" name="Chainfist" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="bb146222-560d-0e59-24aa-89e901af71c8" targetId="dd5fa131-b87d-aeb0-9573-38dff71ed22f" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="1a01a481-8c10-4a96-6d21-a44a15d09ad6" name="Power Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="3285198d-4e11-d9ba-8e69-997314abfece" targetId="e9f34442-a19c-77ab-104a-24adebb6f8f6" linkType="entry group">
+						  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+			  </entries>
+			  <entryGroups/>
+              <modifiers>
+				<modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+			  </modifiers>
+              <links/>
+			</entryGroup>
+			<entryGroup id="13a1400f-7099-9159-164f-10b3d913c898" name="Terminator ranged weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+			  <entries>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1846" name="Combi-Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b551" targetId="1ed42f35-5eee-5260-031d-6e955b004a36" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1823" name="Combi-Weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b566" targetId="984c6378-04a8-4ae7-6636-cff4a77e639d" linkType="entry group">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+			  </entries>
+			  <entryGroups/>
+              <modifiers>
+				<modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+			  </modifiers>
+              <links/>
+			</entryGroup>
+		  </entryGroups>
           <modifiers/>
           <rules/>
           <profiles/>
@@ -3571,7 +3640,7 @@ If Abaddon is in the primary force, he must be the warlord.</description>
                   <rules/>
                   <profiles/>
                   <links>
-                    <link id="3285198d-4e11-d9ba-8e69-997314abfecb" targetId="eeb1d2a0-64f7-e685-b25f-701af0206fbc" linkType="entry group">
+                    <link id="3285198d-4e11-d9ba-8e69-997314abfecb" targetId="e9f34442-a19c-77ab-104a-24adebb6f8f6" linkType="entry group">
                       <modifiers/>
                     </link>
                   </links>
@@ -3831,7 +3900,7 @@ If Abaddon is in the primary force, he must be the warlord.</description>
         </entry>
       </entries>
       <entryGroups>
-        <entryGroup id="15de0774-d7f8-6f6c-869e-c5018665c12f" name="Heavy Weapons" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="15de0774-d7f8-6f6c-869e-c5018665c12f" name="Heavy Weapons" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="f32bee92-9332-52ad-2743-d0877f8dce5c" name="Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -3859,7 +3928,19 @@ If Abaddon is in the primary force, he must be the warlord.</description>
             </entry>
           </entries>
           <entryGroups/>
-          <modifiers/>
+          <modifiers>
+			<modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="d11591d1-84c4-239c-7718-2351663067af" field="selections" type="at least" value="4.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+		  </modifiers>
           <links/>
         </entryGroup>
         <entryGroup id="fe1862ba-e6de-b836-b142-b81c348efdaf" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">

--- a/Chaos Space Marines - Supplement - Black Legion.cat
+++ b/Chaos Space Marines - Supplement - Black Legion.cat
@@ -3940,6 +3940,17 @@ If Abaddon is in the primary force, he must be the warlord.</description>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+			<modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="d11591d1-84c4-239c-7718-2351663067af" field="selections" type="at least" value="9.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
 		  </modifiers>
           <links/>
         </entryGroup>

--- a/Chaos Space Marines - Supplement - Black Legion.cat
+++ b/Chaos Space Marines - Supplement - Black Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d2336634-cdcd-4391-2b54-1dac0890820f" revision="16" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Supplement - Black Legion (2013)" authorName="BSData Team (Original by SincerelyN00b, ChrisTodd)" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d2336634-cdcd-4391-2b54-1dac0890820f" revision="17" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Supplement - Black Legion (2013)" authorName="BSData Team (Original by SincerelyN00b, ChrisTodd)" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="4c715b0c-8095-e2df-dd63-ae8212a40b73" name="[FW] Arkos the Faithless (IA: Apoc 2013)" points="130.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA Apoc 2013" page="153">
       <entries>

--- a/Chaos Space Marines - Supplement - Crimson Slaughter.cat
+++ b/Chaos Space Marines - Supplement - Crimson Slaughter.cat
@@ -4775,133 +4775,145 @@ If Abaddon is in the primary force, he must be the warlord.</description>
         </entry>
         <entry id="585adadb-8c9e-8be3-8435-4dc95faec9a8" name="Terminator" points="31.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="9c9e2261-0e09-cf23-9bbe-1a2862841d19" name="Lightning Claw" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+		    <entry id="4401dfb4-1119-7970-5a2f-85544fcf1842" name="Replace all weapons w/ Pair of Lightning Claws" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="dbff695f-27e4-500c-2003-20654db27408" targetId="9ead2eb0-aabe-6e63-1ba8-b28bd40de3dd" linkType="profile">
+                <link id="caa09472-d1d4-8b38-8c16-d3a5b957b552" targetId="9ead2eb0-aabe-6e63-1ba8-b28bd40de3dd" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
-            </entry>
-            <entry id="822753c6-8c2e-f6fe-e2d7-f73042b1b614" name="Powerfist" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="ddee1076-e0e6-7daa-4a0e-6aaf74581a77" targetId="2473fe3a-3c6f-7cc1-6e0b-c322024309b1" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="45feb3b7-4cd6-bea6-a65e-f331c9df17dc" name="Chainfist" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3675b2a3-8d52-35ff-a340-6cdf2ae1a534" targetId="7368df17-4202-421e-7a46-0ff334797efe" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="e786ffa0-14f9-32ca-4fd6-9070f45b4b83" name="Combi weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="dd1c47cc-b378-39b8-40c7-acd816b388b3" targetId="33291056-0718-8424-3cf3-1832bfb1ebb3" linkType="entry group">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="ef7dd172-464d-18a4-4b25-21fd5cb60369" name="Pair of Lightning Claws" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4ce87b7b-f285-2b29-5850-1c695b9c0fd4" targetId="9ead2eb0-aabe-6e63-1ba8-b28bd40de3dd" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f43c5de1-6785-5032-d2d3-11f98c090580" name="Heavy Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="28968b20-aac4-108e-2c4d-7f8f0c0fe629" name="Heavy Weapons" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-                  <entries>
-                    <entry id="5df572a7-ec94-767f-fc4b-67cb8a32d58b" name="Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links>
-                        <link id="1edc644d-e5df-164c-3831-12b3d966e235" targetId="df36e005-a135-e3f5-4617-2c3cf2427861" linkType="profile">
-                          <modifiers/>
-                        </link>
-                      </links>
-                    </entry>
-                    <entry id="6af5b4c1-3eeb-c7d9-0418-8e6bae169f5b" name="Reaper Autocannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links>
-                        <link id="0eae02fc-7f1c-9130-9cb2-70e704210fa9" targetId="b455600c-a433-d2e8-2dc2-2de983806211" linkType="profile">
-                          <modifiers/>
-                        </link>
-                      </links>
-                    </entry>
-                  </entries>
-                  <entryGroups/>
-                  <modifiers>
-                    <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="585adadb-8c9e-8be3-8435-4dc95faec9a8" field="selections" type="less than" value="4.0"/>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="3127f23e-f69b-fc7f-3864-f021c8702e9a" field="selections" type="less than" value="1.0"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="increment" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="585adadb-8c9e-8be3-8435-4dc95faec9a8" field="selections" type="equal to" value="9.0"/>
-                            <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="3127f23e-f69b-fc7f-3864-f021c8702e9a" field="selections" type="equal to" value="1.0"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <links/>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
             </entry>
           </entries>
-          <entryGroups/>
+          <entryGroups>
+			<entryGroup id="13a1400f-7099-9159-164f-10b3d913c892" name="Terminator CCW" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+			  <entries>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1845" name="Lightning Claw" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b554" targetId="9ead2eb0-aabe-6e63-1ba8-b28bd40de3dd" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="0ae4c849-0881-d972-5c1f-02833ec8b04c" name="Powerfist" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="5da58c92-32fc-1b59-53b9-16b1f95bc97b" targetId="2473fe3a-3c6f-7cc1-6e0b-c322024309b1" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="0bc15bda-f729-8842-c6ee-9f9f95af3f21" name="Chainfist" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="bb146222-560d-0e59-24aa-89e901af71c8" targetId="7368df17-4202-421e-7a46-0ff334797efe" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="1a01a481-8c10-4a96-6d21-a44a15d09ad6" name="Power Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="3285198d-4e11-d9ba-8e69-997314abfece" targetId="6c68fe60-98b2-93a3-97f0-9dcfa5023e65" linkType="entry group">
+						  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+			  </entries>
+			  <entryGroups/>
+              <modifiers>
+				<modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c892" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+			  </modifiers>
+              <links/>
+			</entryGroup>
+			<entryGroup id="13a1400f-7099-9159-164f-10b3d913c898" name="Terminator ranged weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+			  <entries>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1846" name="Combi-Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b551" targetId="8a06c896-1035-4a0e-0743-6edb1a4b3b1f" linkType="profile">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+				<entry id="4401dfb4-1119-7970-5a2f-85544fcf1823" name="Combi-Weapon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+				  <entries/>
+				  <entryGroups/>
+				  <modifiers/>
+				  <rules/>
+				  <profiles/>
+				  <links>
+					<link id="caa09472-d1d4-8b38-8c16-d3a5b957b566" targetId="33291056-0718-8424-3cf3-1832bfb1ebb3" linkType="entry group">
+					  <modifiers/>
+					</link>
+				  </links>
+				</entry>
+			  </entries>
+			  <entryGroups/>
+              <modifiers>
+				<modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+				<modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+				  <conditions>
+					<condition parentId="13a1400f-7099-9159-164f-10b3d913c898" childId="4401dfb4-1119-7970-5a2f-85544fcf1842" field="selections" type="at least" value="1.0"/>
+				  </conditions>
+				  <conditionGroups/>
+				</modifier>
+			  </modifiers>
+              <links/>
+			</entryGroup>
+		  </entryGroups>
           <modifiers/>
           <rules/>
           <profiles/>
@@ -5094,6 +5106,49 @@ If Abaddon is in the primary force, he must be the warlord.</description>
         </entry>
       </entries>
       <entryGroups>
+		<entryGroup id="15de0774-d7f8-6f6c-869e-c5018665c12f" name="Heavy Weapons" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="f32bee92-9332-52ad-2743-d0877f8dce5c" name="Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b7a23867-5ca7-f6c7-d1bd-b768e6d88916" targetId="caf9fcec-d7c6-5e23-d9c7-043019f03a3f" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="def929bc-fddb-6277-f270-d23130932d02" name="Reaper Autocannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="6b44874b-a343-4a09-8ec0-96c4b07fe77c" targetId="78e1eda3-9f50-5c7a-7ef9-fa4724e5e6b9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers>
+			<modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="585adadb-8c9e-8be3-8435-4dc95faec9a8" field="selections" type="at least" value="4.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+		  </modifiers>
+          <links/>
+        </entryGroup>
         <entryGroup id="76e88eca-d85f-e0ef-25f2-e44ecc7db623" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>

--- a/Chaos Space Marines - Supplement - Crimson Slaughter.cat
+++ b/Chaos Space Marines - Supplement - Crimson Slaughter.cat
@@ -5146,6 +5146,17 @@ If Abaddon is in the primary force, he must be the warlord.</description>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+			<modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition parentId="ea43513d-eae7-f93a-0b2b-c26b9661a26d" childId="585adadb-8c9e-8be3-8435-4dc95faec9a8" field="selections" type="at least" value="9.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
 		  </modifiers>
           <links/>
         </entryGroup>

--- a/Chaos Space Marines - Supplement - Crimson Slaughter.cat
+++ b/Chaos Space Marines - Supplement - Crimson Slaughter.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="528a71c7-fca2-a2b1-89ef-a77784f505fb" revision="15" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Supplement - Crimson Slaughter (2014)" authorName="SincerelyNoob, JJ, Magc8Ball, Grarg, Ansacs, NebSeele" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="528a71c7-fca2-a2b1-89ef-a77784f505fb" revision="16" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Supplement - Crimson Slaughter (2014)" authorName="SincerelyNoob, JJ, Magc8Ball, Grarg, Ansacs, NebSeele" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="e04e4fdc-f3f4-b49a-79ac-b87f3e31d401" name="[FW] Arkos the Faithless, Scion of Alpharius (IA: Apoc)" points="130.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="IA Apoc 2013" page="153">
       <entries>


### PR DESCRIPTION
I've encountered multiple issues with Terminators across all 3 CSM book and wanted to fix them as well as see if I could improve the weapon selection menu (it has no configuration restrictions at all right now, so you can take all upgrades at the same time). Here's the list of things I've done:
1. Fixed issue in Black Legion supplement, where Power Weapon entry for Terminator Champion was actually pointing to Force Weapons
2. Added an option for Power Weapon for Terminators in all books (there was no before!!)
3. Moved Heavy Weapon option to Squad Level in CS and CSM books (so its the same as BL book), rather than have it per individual Terminator
4. Added a check so that Heavy Weapons are limited to 1 if there's at least 5 models in the squad and to 2 if there's at least 10 models.
5. Reworked weapon selection menu to be similar to squad leader's, as before all the options could be taken at the same time (there were no limits what so ever). Split them into CCW and Ranged single choice groups and also added an option to replace both with pair of Lightning Claws. Appropriate errors are shown if invalid combination is selected now

I've tested the changes locally and seems to be working fine. Hopefully you'll find this useful and let me know if there's some issues with my changes that I've overlooked.

Thanks,
Paulius
