### PR TITLE
Improve selection of Flakk missiles to avoid the 'add' button

### DIFF
--- a/Blood Angels - Codex (2014).cat
+++ b/Blood Angels - Codex (2014).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6cacb5fc-d6bf-078d-307e-6f16c72d5f2a" revision="9" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="1" battleScribeVersion="1.15" name="Blood Angels: Codex (2014)" books="Codex: Blood Angels" authorName="Kangodo (and others)" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6cacb5fc-d6bf-078d-307e-6f16c72d5f2a" revision="10" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="1" battleScribeVersion="1.15" name="Blood Angels: Codex (2014)" books="Codex: Blood Angels" authorName="Kangodo (and others)" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="fa1acfe9-aaea-9141-a026-3a83f5286cee" name="Angel&apos;s Fury Spearhead Force" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
@@ -12005,29 +12005,16 @@ The Knight has a 4+ invulnerable save against all hits on that facing until the 
               </links>
             </entry>
             <entry id="2d09f587-d8be-ae77-6691-da7238f443f6" name="Missile launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="39f5ca6f-6245-2259-335b-f071c2d972f5" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="ff5e20f5-9c41-7582-32dd-87701523ce83" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
+              <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="7f49628f-f920-7cad-341f-a9da9cae96a3" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                <link id="bc71db9a-8f3c-ff3b-a272-b8475e5d110f" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
                   <modifiers/>
                 </link>
-                <link id="bc71db9a-8f3c-ff3b-a272-b8475e5d110f" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
+                <link id="839fc070-20b9-06db-9553-9480344c2580" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
@@ -12064,6 +12051,24 @@ The Knight has a 4+ invulnerable save against all hits on that facing until the 
               <profiles/>
               <links>
                 <link id="0918ef32-9cdb-33f1-2b19-d3787ce31837" targetId="dae65f10-3c29-371d-8503-dcd53fbe986f" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7c1140ce-952b-31fd-08ec-c5f68d3f5e68" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="acd46ac5-14cf-e60e-31d1-b6614b511a3d" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="ad9978ac-eceb-492e-1e2c-269e07311ecf" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="f4ea7109-2707-a9ef-2714-cadf9525b2f3" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
                   <modifiers/>
                 </link>
               </links>


### PR DESCRIPTION
Instead of having an "add" button for missile launchers (devastator squad), have two different entries:
- "Missile launchers" (ie. Krak, Frag, 15 pts)
- "Missile launchers with Flakk" (ie. Krak, Frag, Flakk, 25pts)
  I find this to be more intuitive and easier to use.
