### PR TITLE
Bug Fixes for Issues #821 and #818

### DIFF
--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="139" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="140" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="d333bebf-fda1-d63f-3a91-f3c4a81166e1" name="[Apoc] Cult of Destruction" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
@@ -15578,7 +15578,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                 </link>
               </links>
             </entry>
-            <entry id="512a5a0e-8810-6d38-007e-db723894edf7" name="Mark of Tzeentch" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="512a5a0e-8810-6d38-007e-db723894edf7" name="Mark of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers>

--- a/Eldar - Codex.cat
+++ b/Eldar - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="96cb9a0c-277b-20f8-c454-4ef85899ae1b" revision="31" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Eldar: Codex (2013)" authorName="Magc8Ball" authorContact="jason@titaniumspork.org" authorUrl="https://github.com/BSData/wh40k#warhammer-40000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="96cb9a0c-277b-20f8-c454-4ef85899ae1b" revision="32" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Eldar: Codex (2013)" authorName="Magc8Ball" authorContact="jason@titaniumspork.org" authorUrl="https://github.com/BSData/wh40k#warhammer-40000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="c1b3594a-2e16-4638-80c7-d34eeb0df10c" name="Asurmen, The Hand of Asuryan" points="220.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Eldar (2013)" page="56">
       <entries>
@@ -3404,6 +3404,10 @@ to either suffer 1 Wound and pass the Psychic test, or not suffer a Wound and in
         <rule id="58a10b3b-e5d3-63fc-e6a5-8ff16ee45ed1" name="Walker of the Hidden Path" hidden="false" book="Codex: Eldar (2013)" page="55">
           <modifiers/>
         </rule>
+        <rule id="37fc-c53a-e586-3d65" name="Master of Pathfinders" hidden="false">
+          <description>If your army contains Illic Nightspear, any number of Eldar Ranger units can be upgraded to Alaitoc Pathfinders at an additional cost of 13 points per model. In addition to the normal rules for Eldar Rangers, Alaitoc Pathfinders have the Shrouded and Sharpshot special rules.</description>
+          <modifiers/>
+        </rule>
       </rules>
       <profiles>
         <profile id="e2635f30-345d-7afd-c419-698bf9dc344f" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Illic Nightspear" hidden="false" page="56">
@@ -4564,28 +4568,7 @@ to either suffer 1 Wound and pass the Psychic test, or not suffer a Wound and in
     <entry id="832e8b8c-ff8c-42ce-99a9-a361df2c2c89" name="Rangers" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="8a5b057f-9565-49ea-a02f-cb8e578d325e" name="Ranger" points="12.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="c4040401-1d20-46a3-bff4-dfc605b9b8be" name="Pathfinder" points="13.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="490e2e7e-0100-9b1b-88e7-0c59aa7c0d1a" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="81e8af7e-4395-b492-8d66-b6643c811584" targetId="fd52d811-f4a4-5d1b-b0dd-b803062f3974" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="a9b93117-5ad5-4914-65d9-a88b1c67f60d" targetId="c175b077-1bd0-f520-74c2-d29bab79ab7b" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -4603,9 +4586,63 @@ to either suffer 1 Wound and pass the Psychic test, or not suffer a Wound and in
                 <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
                 <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
               </characteristics>
-              <modifiers/>
+              <modifiers>
+                <modifier type="hide" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="832e8b8c-ff8c-42ce-99a9-a361df2c2c89" childId="b6ad-0553-b758-27ef" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </profile>
+            <profile id="15b1-f53a-d114-5bf1" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Alaitoc Pathfinder" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+              </characteristics>
+              <modifiers>
+                <modifier type="hide" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="832e8b8c-ff8c-42ce-99a9-a361df2c2c89" childId="b6ad-0553-b758-27ef" field="selections" type="equal to" value="0.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
+          <links/>
+        </entry>
+        <entry id="b6ad-0553-b758-27ef" name="Upgrade to Alaitoc Pathfinders" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="increment" field="points" value="13.0" repeat="true" numRepeats="1" incrementParentId="direct parent" incrementChildId="8a5b057f-9565-49ea-a02f-cb8e578d325e" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="force type" childId="490e2e7e-0100-9b1b-88e7-0c59aa7c0d1a" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="force type" childId="490e2e7e-0100-9b1b-88e7-0c59aa7c0d1a" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <rules/>
+          <profiles/>
           <links/>
         </entry>
       </entries>
@@ -4644,6 +4681,26 @@ to either suffer 1 Wound and pass the Psychic test, or not suffer a Wound and in
         </link>
         <link id="39a7e8cf-6aea-582d-fdce-e196d6a29997" targetId="bd53bd37-d0b7-8e01-e520-81d5f52b7964" linkType="rule">
           <modifiers/>
+        </link>
+        <link id="1da5-d1d5-c4e0-87ca" targetId="fd52d811-f4a4-5d1b-b0dd-b803062f3974" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="832e8b8c-ff8c-42ce-99a9-a361df2c2c89" childId="b6ad-0553-b758-27ef" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="c978-a11b-2379-cc9b" targetId="c175b077-1bd0-f520-74c2-d29bab79ab7b" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="832e8b8c-ff8c-42ce-99a9-a361df2c2c89" childId="b6ad-0553-b758-27ef" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
       </links>
     </entry>


### PR DESCRIPTION
Mark of Tzeentch had an incorrect cost of 1 point for the Mark itself.
Corrected to 0 points.
