### PR TITLE
Fixed AP value of Twin Icarus Autocannon per #993

### DIFF
--- a/Skitarii - Codex.cat
+++ b/Skitarii - Codex.cat
@@ -2364,7 +2364,7 @@ Also units may re-roll charge range until end of turn.</description>
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
-        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
         <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2, Skyfire, Interceptor, Twin-linked"/>
       </characteristics>
       <modifiers/>


### PR DESCRIPTION
Fixed AP value of Twin Icarus Autocannon per #993
