### PR TITLE
Improve all selections of Flakk missiles to avoid the 'add' button

### DIFF
--- a/Blood Angels - Codex (2014).cat
+++ b/Blood Angels - Codex (2014).cat
@@ -168,20 +168,7 @@
                       </links>
                     </entry>
                     <entry id="03d274f7-7cba-a2e2-e570-33c24257742d" name="Missile launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                      <entries>
-                        <entry id="833ff04c-74cd-12ed-69c0-ee7bf97831e5" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                          <entries/>
-                          <entryGroups/>
-                          <modifiers/>
-                          <rules/>
-                          <profiles/>
-                          <links>
-                            <link id="1e884b5f-08b0-a7ce-cfb2-5d8fb9fa61c4" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                              <modifiers/>
-                            </link>
-                          </links>
-                        </entry>
-                      </entries>
+                      <entries/>
                       <entryGroups/>
                       <modifiers/>
                       <rules/>
@@ -227,6 +214,24 @@
                       <profiles/>
                       <links>
                         <link id="08222f97-bc30-b059-ed03-3d637e9157af" targetId="dae65f10-3c29-371d-8503-dcd53fbe986f" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="7fed-4181-615d-74a8" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="0f99-0f7b-b4fd-0ab3" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="ad1e-2736-efec-4146" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="8f9a-cf38-cd3e-2e39" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
                           <modifiers/>
                         </link>
                       </links>
@@ -2055,20 +2060,7 @@
                           </links>
                         </entry>
                         <entry id="d6ce9a4c-b355-3239-8601-f84d84265f26" name="Missile Launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                          <entries>
-                            <entry id="c8315200-a86e-55fa-1962-c3cfa9fa1163" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                              <entries/>
-                              <entryGroups/>
-                              <modifiers/>
-                              <rules/>
-                              <profiles/>
-                              <links>
-                                <link id="e85737d7-68ba-0e84-aea2-2faa5c7a8c0d" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                                  <modifiers/>
-                                </link>
-                              </links>
-                            </entry>
-                          </entries>
+                          <entries/>
                           <entryGroups/>
                           <modifiers/>
                           <rules/>
@@ -2141,6 +2133,24 @@
                               <modifiers/>
                             </link>
                             <link id="d27b2e34-7298-c445-ad6a-e99c1094eea7" targetId="d209e2e9-a2e8-c041-66c3-059c3b9cd6e0" linkType="rule">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="1e2b-dc18-643c-3cc4" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="b99e-36fe-55bc-b5c0" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                              <modifiers/>
+                            </link>
+                            <link id="ce15-d4ad-221b-f29c" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
+                              <modifiers/>
+                            </link>
+                            <link id="9575-be38-9b2f-9803" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
                               <modifiers/>
                             </link>
                           </links>
@@ -17333,20 +17343,7 @@ May only be taken in a secondary detachment if that detachment also includes a R
             <entryGroup id="dbd3f1f8-52b4-7971-f2f9-069611487b04" name="Heavy Weapon" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="bde5e39e-3b6c-9089-e3e0-4d6024759fca" name="Missile Launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries>
-                    <entry id="f928e509-ef03-9069-ac00-51f8550871bb" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links>
-                        <link id="30e3d7aa-0e43-d8aa-9501-1d1f083c61b8" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                          <modifiers/>
-                        </link>
-                      </links>
-                    </entry>
-                  </entries>
+                  <entries/>
                   <entryGroups/>
                   <modifiers/>
                   <rules/>
@@ -17387,6 +17384,24 @@ May only be taken in a secondary detachment if that detachment also includes a R
                   <profiles/>
                   <links>
                     <link id="6327afc5-6d1a-1422-5474-c8c66e0992ed" targetId="f4b79743-bcaa-0a58-fb1e-4bc44cb02986" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="28c9-9596-8b35-4b58" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="97a1-0bb6-fe3f-721f" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="c642-49de-3191-6fca" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="f955-4084-32b5-ec2e" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
                       <modifiers/>
                     </link>
                   </links>
@@ -18030,20 +18045,7 @@ May only be taken in a secondary detachment if that detachment also includes a R
                   </links>
                 </entry>
                 <entry id="3fc52cd0-c131-5851-f4e7-6d604ce96e3a" name="Missile Launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries>
-                    <entry id="4943eb4d-6c85-625c-16e3-86cea7dfefa6" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links>
-                        <link id="314525ce-7421-1b4c-7b2c-64638bf8259c" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                          <modifiers/>
-                        </link>
-                      </links>
-                    </entry>
-                  </entries>
+                  <entries/>
                   <entryGroups/>
                   <modifiers/>
                   <rules/>
@@ -18116,6 +18118,24 @@ May only be taken in a secondary detachment if that detachment also includes a R
                       <modifiers/>
                     </link>
                     <link id="2e32e883-0205-3a29-a861-b8a94e9629cd" targetId="d209e2e9-a2e8-c041-66c3-059c3b9cd6e0" linkType="rule">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="7929-67d9-6f97-1d00" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="7140-7d76-3608-f985" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="54fc-e22a-5e82-2b63" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="c327-6ad7-f4f2-6ed4" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
                       <modifiers/>
                     </link>
                   </links>
@@ -18518,20 +18538,7 @@ May only be taken in a secondary detachment if that detachment also includes a R
               </links>
             </entry>
             <entry id="91fa2f78-16c2-2ef1-4d39-afa5465ae257" name="Missile launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="a516b385-6115-37c6-e09b-84b261233ebe" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="bb0c082a-3526-a660-743a-bd9d4eb07567" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
+              <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
@@ -18577,6 +18584,24 @@ May only be taken in a secondary detachment if that detachment also includes a R
               <profiles/>
               <links>
                 <link id="5ab1571b-0429-7864-1670-6213c9f2db0d" targetId="dae65f10-3c29-371d-8503-dcd53fbe986f" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="42de-cddb-cd83-8b08" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="22f9-7468-7f88-4ad2" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="1e56-d9c0-d31e-1f9e" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="3ba6-8bd3-584b-8ac0" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
@@ -20579,20 +20604,7 @@ If your Warlord is an Imperial Knight, that Knight is a character. A Knight Warl
           </links>
         </entry>
         <entry id="c680d923-ffb1-5536-17a5-faf3ea2355ef" name="Missile launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="31e153c4-6bef-7e2a-83e1-e42219833362" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="0b56d326-d84f-59ce-3f17-bd5903831427" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -20642,6 +20654,24 @@ If your Warlord is an Imperial Knight, that Knight is a character. A Knight Warl
             </link>
           </links>
         </entry>
+        <entry id="723e-7e05-e4ea-8412" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="8ce3-e752-6a20-6488" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="5c48-f833-e34d-b0a9" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="38dd-ac50-416f-a203" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
       </entries>
       <entryGroups/>
       <modifiers/>
@@ -20686,20 +20716,7 @@ If your Warlord is an Imperial Knight, that Knight is a character. A Knight Warl
           </links>
         </entry>
         <entry id="8b00ba17-7a5d-5119-256f-c1e04e21dfce" name="Missile launcher" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ed4daa65-cd88-2081-2b07-2718a4310d5b" name="Flakk missiles" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="b0ae7fd1-c922-7cfb-b9a8-40308a025fba" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -20745,6 +20762,24 @@ If your Warlord is an Imperial Knight, that Knight is a character. A Knight Warl
           <profiles/>
           <links>
             <link id="dcadf923-cce3-ef35-9e02-521582d8a3a0" targetId="dae65f10-3c29-371d-8503-dcd53fbe986f" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="c90b-555e-5982-abe5" name="Missile launcher (with Flakk)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="81da-4478-4bec-5ccd" targetId="f806c2d3-6dad-2be6-224c-78b1e051f0c1" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="27a9-c035-38af-dc1d" targetId="7d2bb03d-9e0b-94b9-84bc-a1d3fce5578c" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="fd5e-e653-236d-c2ab" targetId="8a972647-4651-47af-e5dd-4fc4e35e60aa" linkType="profile">
               <modifiers/>
             </link>
           </links>


### PR DESCRIPTION
A while ago I changed a "Missile Launcher" entry in order to avoid the "add" button for Flakk. I've now changed all entries that contained a Missile Launcher as an option to be identical to this system.
