### PR TITLE
Necron Decurion - Ever-living Rule Bug

### DIFF
--- a/Necrons - Codex (2015).cat
+++ b/Necrons - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="026a-37f6-fa3a-c213" revision="7" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Necrons: Codex (2015)" authorName="Kangodo, Tobias" authorContact="Report issues and bugs for this Codex here:" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="026a-37f6-fa3a-c213" revision="8" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Necrons: Codex (2015)" authorName="Kangodo, Tobias" authorContact="Report issues and bugs for this Codex here:" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="c528a153-c346-46d9-a7e5-d5e0fd485ea5" name="Acquisition Phalanx" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="40k Apocalypse" page="169">
       <entries/>
@@ -1348,6 +1348,12 @@ The removed units may Deep Strike back into the game and the first placed model 
           </conditions>
           <conditionGroups/>
         </modifier>
+        <modifier type="show" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="force type" childId="5035-9fad-cd58-1bce" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
       </modifiers>
     </rule>
   </rules>
@@ -1487,9 +1493,6 @@ The removed units may Deep Strike back into the game and the first placed model 
     <link id="6454-9f59-1f02-8b87" targetId="76f6-bd0f-5895-cfa2" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
       <modifiers/>
     </link>
-    <link id="3c00-e5ad-3efb-1c06" targetId="dac9-7a63-1c57-2715" linkType="entry" categoryId="bf93-7277-bf48-16f7">
-      <modifiers/>
-    </link>
     <link id="788c-7385-e47f-b12d" targetId="dac9-7a63-1c57-2715" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
       <modifiers/>
     </link>
@@ -1551,6 +1554,9 @@ The removed units may Deep Strike back into the game and the first placed model 
       <modifiers/>
     </link>
     <link id="7c8e-00b2-db56-414a" targetId="3b4f-faec-3104-33da" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="31f5-00ae-4deb-f2fa" targetId="dac9-7a63-1c57-2715" linkType="entry" categoryId="bf93-7277-bf48-16f7">
       <modifiers/>
     </link>
   </links>
@@ -4635,6 +4641,18 @@ If the Tomb Ziggurat is destroyed, the docked warmachine takes a S10, AP2 hit.</
         </link>
       </links>
     </entry>
+    <entry id="febf-4717-a407-6e99" name="Phase Shifter" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="3942-5a88-8de8-3f41" targetId="b8e2-3d2d-ada9-ccec" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="6b76-c128-51ae-b42f" name="Powers of the C&apos;tan - Coalescent" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
       <entryGroups/>
@@ -6276,18 +6294,6 @@ If the Tomb Ziggurat is destroyed, the docked warmachine takes a S10, AP2 hit.</
       </rules>
       <profiles/>
       <links/>
-    </entry>
-    <entry id="febf-4717-a407-6e99" name="Phase Shifter" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3942-5a88-8de8-3f41" targetId="b8e2-3d2d-ada9-ccec" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
     </entry>
   </sharedEntries>
   <sharedEntryGroups>


### PR DESCRIPTION
Re-set conditions for 'Ever-living' command benefits.

For Issue #1080 
