### PR TITLE
Skyrunner Warlock's cost

### DIFF
--- a/Eldar Craftworlds - Codex (2015).cat
+++ b/Eldar Craftworlds - Codex (2015).cat
@@ -9129,7 +9129,7 @@
         </link>
       </links>
     </entry>
-    <entry id="0d1d-b348-4865-0af0" name="Skyrunner Warlock" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entry id="0d1d-b348-4865-0af0" name="Skyrunner Warlock" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="2d92-a324-7f6d-dfc2" name="Skyrunner" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Craftworld Eldar(2015)">
           <entries>


### PR DESCRIPTION
name="Skyrunner Warlock" points="50.0" to name="Skyrunner Warlock" points="35.0"
Warlock is cost 35pnt + 15 for a bike, 50pnt in total. Right now Skyrunner Warlock is cost 65.
