### PR TITLE
v160

### DIFF
--- a/Chaos Space Marines - Codex.cat
+++ b/Chaos Space Marines - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="159" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5af86795-95c1-a1eb-c333-17137242b62f" revision="160" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Space Marines: Codex (2012)" authorName=" BSData team (Originally authored by SincerelyNoob ,JJ, Magc8Ball, Grarg)" authorUrl="http://battlescribedata.appspot.com/#/repos" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="c765439d-7af4-5eea-85b4-0f8458870cd6" name="[Apoc] Lords of the Black Crusade" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
@@ -1996,7 +1996,145 @@
     </entry>
     <entry id="010e-535c-8118-3909" name="Kranon&apos;s Helguard" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="4717-cdae-0602-3086" name="Cultists" defaultEntryId="f351-64cf-5e46-6b36" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="f351-64cf-5e46-6b36" targetId="b9a9-557f-f8fb-4377" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="minSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="91ee-56ac-ffda-bf12" name="Land Raider" defaultEntryId="984c-6a55-8c15-24ef" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="984c-6a55-8c15-24ef" targetId="c5fc-da7b-9c1f-bfe4" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxInForce" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="1753-e38f-022b-11d8" name="Chaos Lord" defaultEntryId="0314-a4cb-0dc1-c723" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="0314-a4cb-0dc1-c723" targetId="598f-3cba-b8c5-e748" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="9855-9891-cae1-3e50" name="Terminators" defaultEntryId="fbb4-7b8b-82f6-3fab" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="fbb4-7b8b-82f6-3fab" targetId="8a3b-80c7-0cf3-e044" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="8321-ad78-d3bd-655f" name="Chosen" defaultEntryId="a4ee-c228-5c7e-5500" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a4ee-c228-5c7e-5500" targetId="d553-752e-86d1-19fd" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="75de-9c09-1aea-55aa" name="Helbrute" defaultEntryId="84a4-485c-7ffa-af0c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="84a4-485c-7ffa-af0c" targetId="c3c4-425d-e94e-1b26" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="b8a6-1b80-838d-9319" name="Raptors" defaultEntryId="1286-88e2-bc6f-603a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1286-88e2-bc6f-603a" targetId="661b-14f1-8fd9-84b5" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules>
         <rule id="7953-d7f1-011a-8c56" name="Swarm of Phantasms" hidden="false">
@@ -2011,94 +2149,6 @@ Enemy units within 12&quot; of a unit in this formation subtract 1 from their Ba
       </rules>
       <profiles/>
       <links>
-        <link id="495c-dd58-2eba-9835" targetId="598f-3cba-b8c5-e748" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="aeaa-48b7-ecc9-a3e1" targetId="d553-752e-86d1-19fd" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="9de8-7b4d-6100-b6eb" targetId="8a3b-80c7-0cf3-e044" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="8e12-67f0-7f71-403c" targetId="b9a9-557f-f8fb-4377" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="0719-4e49-baf5-e0e1" targetId="661b-14f1-8fd9-84b5" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="fbf9-9b64-3212-a6a9" targetId="c3c4-425d-e94e-1b26" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="355b-d797-012e-0a19" targetId="c5fc-da7b-9c1f-bfe4" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxInForce" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
         <link id="d1a6-4cce-6a2b-813d" targetId="4bf37f51-e484-ff05-0545-f477a09d1f6b" linkType="rule">
           <modifiers/>
         </link>
@@ -2661,453 +2711,6 @@ Enemy units within 12&quot; of a unit in this formation subtract 1 from their Ba
     </link>
   </links>
   <sharedEntries>
-    <entry id="be3e-2b76-2fc2-46ce" name="Cult of Destruction" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
-      <entries>
-        <entry id="961c-61c6-5929-c4aa" name="Obliterator Units" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="7cda-6ee0-93d9-0920" name="Obliterators" points="70.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="d5d7-f87b-46d6-80ae" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="fb79-b8de-205d-ee3a" name="Mark of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-                <entry id="7d6a-a418-0433-0ccf" name="Mark of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="8.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-                <entry id="8ec0-2fa7-cbc9-d6f0" name="Mark of Nurgle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-                <entry id="874d-da5c-1dde-1e38" name="Mark of Slaanesh" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="556a-3e33-63fe-689a" targetId="8716278e-3703-03c2-1f2c-f9b4f243155c" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="4a8e-b8ef-bfff-a098" targetId="1e872ce3-4417-cd8f-5516-ccd120a2b36c" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6a92-8767-da10-38d1" targetId="6fa0c91c-6324-f45e-ad42-620666a28e9d" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="8456-826a-23c7-c45d" targetId="65fc22df-1d64-cf1b-8e97-f9a44fbc0114" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e084-3f82-65b9-6a0f" targetId="10c2dc32-e122-a91a-2071-0dffec452951" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="58f4-6b86-f639-dbae" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="9e72-cdbb-207f-d981" name="Mutilator Units" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="5494-8794-0ede-a889" name="Mutilators" points="55.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="50d5-2447-efd3-0477" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries>
-                    <entry id="9cee-b38a-3855-e8a1" name="Mark of Khorne" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links/>
-                    </entry>
-                    <entry id="197b-112d-74b3-5a4a" name="Mark of Tzeentch" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links/>
-                    </entry>
-                    <entry id="9691-3733-5fdb-1de7" name="Mark of Nurgle" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links/>
-                    </entry>
-                    <entry id="9166-e6ac-3ea1-c5aa" name="Mark of Slaanesh" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links/>
-                    </entry>
-                  </entries>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links/>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="39a6-745e-3c4a-ccd4" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="fc10-3e12-aeec-d6a5" targetId="57e9f954-ec4a-1bfc-359d-e59d9e1f92a2" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="3337-6411-6028-abe2" targetId="65fc22df-1d64-cf1b-8e97-f9a44fbc0114" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="40b8-4446-d0a1-1cd7" targetId="24a441c3-9970-5437-cfab-db3e08852f98" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b967-d220-b5b8-89cf" targetId="1e872ce3-4417-cd8f-5516-ccd120a2b36c" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5bc2-f36a-e8a3-ef95" targetId="8716278e-3703-03c2-1f2c-f9b4f243155c" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="aa23-3fb0-9730-028a" targetId="bf115a80-562e-f171-648e-8f8af04da18b" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="7f54-d953-a8c2-180c" name="Engines of Destruction" hidden="false">
-          <modifiers/>
-        </rule>
-        <rule id="2535-1576-108a-74f5" name="Orgy of Devastation" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="8deb-3f12-acc9-fd78" name="Heldrake Fear Squadron" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="5c9c-86c0-453e-e666" name="Heldrakes" defaultEntryId="5098-3d4e-7523-bd90" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="5098-3d4e-7523-bd90" targetId="0d77-1f37-3b32-c978" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="34f7-5856-2730-dac6" name="Fuelled by Fear" hidden="false">
-          <description>Removes the Once per Game restriction on Daemonforge. All other restrictions still apply.</description>
-          <modifiers/>
-        </rule>
-        <rule id="bbe0-5271-f392-ca40" name="Harbingers of the Apocalypse" hidden="false">
-          <description>The squadron is deployed with the rest of the army. After deployment but before first turn, the Heldrake may move 60&quot; in which they may make an out of sequence Vector Strike (does not cause Morale checks).
-If the special Vector Strike is used, the squadron may not make another that turn, but may fire its other weapons as normal.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="897a-e3ad-ec5c-6c43" name="The Lost and the Damned" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="77dc-9209-1789-5755" name="Dark Apostle" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a20c-1855-bf53-d75d" targetId="d630-2b65-3996-c1a3" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="c9e5-e242-1f09-721f" name="Limitless in Number" hidden="false">
-          <modifiers/>
-        </rule>
-        <rule id="f093-01be-87cd-0e0c" name="Boundless in Spite" hidden="false">
-          <modifiers/>
-        </rule>
-        <rule id="37fd-c368-57ec-1254" name="Warped by Mutation" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="5eed-5287-cdb2-5a0f" targetId="ea5a4db4-c79e-a76d-51c0-330ee9d4e863" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ec73-e5c1-9eb9-e128" name="Thousand Sons War Coven" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
-      <entries>
-        <entry id="6bdd-a42c-97ea-4842" name="Psychic Choir: Storm of Change" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="2e4b-1b95-1961-3e1f" name="Lifedrain" hidden="false">
-              <description>Each time the power&apos;s used, remove up to 3 models in the formation from play. The number removed is the value of &quot;X&quot;.</description>
-              <modifiers/>
-            </rule>
-            <rule id="2473-2c63-e6b9-07f4" name="Storm of Change" hidden="false">
-              <description>Psychic Choir: 
-Warp Charge 2
-Witchfire Power.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles>
-            <profile id="c1c5-0cf5-2f17-3b30" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Psychic Choir: Storm of Change" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault X, Blast, Lifedrain, Vortex"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="c716-e71b-7547-17c1" targetId="27ff1af5-9050-3cbe-8eee-df27c79a0917" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="c1fd-4fa8-e4da-3f97" name="Ahriman or Mastery Level 3 Sorcerer" defaultEntryId="96d0-9b6d-c8ac-a643" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="96d0-9b6d-c8ac-a643" targetId="4824-f3b6-ebde-3155" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a1f1-1e87-bd31-e5e0" targetId="9832-6438-ea96-d6d6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5d9e-ef58-dffd-9359" name="Mastery Level 1 Sorcerers" defaultEntryId="d5a8-f60d-b398-440d" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d5a8-f60d-b398-440d" targetId="9832-6438-ea96-d6d6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="dfb9-aa36-0b2b-a1f3" name="Tide of Spawn" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
-      <entries>
-        <entry id="15b2-9821-6511-c953" name="Chaos Spawn" points="30.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="3345-3172-44f8-d4c4" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="7eec-ba3a-0f8e-6290" name="Mark of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4dda-d8ae-fb10-1acd" targetId="e53e9738-2619-dece-cdd0-a3b06edcd0a5" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="d91e-127f-22b9-c213" name="Mark of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="b2f3-de5e-58e6-0af3" targetId="f7153095-5189-cd0c-d397-3c5c13fd1168" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="c79f-1ecf-b2a6-09fd" name="Mark of Nurgle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1472-1c58-2c8f-9efe" targetId="2d3dd5aa-ee83-304c-3129-f7ecb73f1928" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a2ae-111a-68b1-b2d6" name="Mark of Slaanesh" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="79e7-f099-c86c-b640" targetId="69dc1813-9e46-c062-cf10-b83e3eff3bad" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="67ad-0112-b73d-333c" name="The Final Blessing of the Gods." hidden="false">
-          <description>The unit is not deployed normally. From turn 2 onwards, choose one friendly un-engaged infantry unit at least 1&quot; away from an enemy model and has the same number of models as this formation. All models in the unit become the spawns in this formation with full wounds and no upgrades (except the mark they already had).
-
-The unit must immediately disembark their transport before turning into the spawn.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="cf8d-e138-0d3e-8b0e" targetId="5d03f0dc-b84b-6878-b36c-2cf4140a053d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="80c3-d333-f5ab-a592" targetId="a29b139e-6d67-8464-7266-814ce16c1205" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="7cdb-4d39-b744-973a" targetId="4bf37f51-e484-ff05-0545-f477a09d1f6b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="fdae-6668-5629-4075" targetId="2a4fd5b9-69cf-5ecf-8225-e07f016c2a52" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1892-54fe-0920-fee6" targetId="b3feb676-c1d4-3d48-a8b7-3aa4a87188ef" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="71fe-c6b9-6b56-8601" targetId="c36b4aae-d2ae-5058-2d3e-80d114a6043a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4e93-e687-b7a4-5c69" targetId="aa1504f8-0ab7-d06c-cb7d-8eef3c2911cd" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
     <entry id="70e4-4d8f-b97f-3aaa" name="[FW] Arkos the Faithless (IA: Vraks)" points="130.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA Vraks 2015" page="153">
       <entries>
         <entry id="feac-0e00-e86d-511f" name="Frag Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -10275,215 +9878,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="17f4-9b8e-8684-fbfe" name="Daemon-Engine Hunting Pack" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="0aff-d2aa-7b6e-2bee" name="Fiends" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="67b4-8831-f550-a51d" targetId="ac6d-d083-8ae2-dc18" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="d906-55c4-03e6-9695" targetId="a374-0611-5092-b88b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="0d70-c046-82b6-eb5f" name="Hunting Pack" hidden="false">
-          <description>After deployment, but before the first turn, nominate one character model int eh enemy army. All vehicles in the spearhead have the Preferred Enemy rule when attacking this model. In addition, if the nominated enemy model is destroyed, the side this formation belongs to scores 1 Strategic Victory Point.</description>
-          <modifiers/>
-        </rule>
-        <rule id="92b6-d646-8f8d-f982" name="Prized Possessions" hidden="false">
-          <description>At the start of the battle, you may nominate one Chaos Warpsmith in the same army to be the Daemon Engine Pack&apos;s owner. Any models from this formation that are within 12&quot; of the owner may use his WS and BS instead of their own.</description>
-          <modifiers/>
-        </rule>
-        <rule id="c238-177c-0266-8c6d" name="Thunderous Charge" hidden="false">
-          <description>If the spearhead is in Rapier Attack Pattern, it may charge even if it Ran in the Shooting phase.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6095-6691-ebad-602a" name="Maelstrom of Gore" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="685c-d63a-648d-9fbb" name="Chaos Lord or Kharn" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7108-fd49-5b64-2917" targetId="08ed-5bd1-f1e7-6419" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c136-9743-b5cb-f422" targetId="598f-3cba-b8c5-e748" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="ff09-e509-0adf-6960" name="Berzerkers" defaultEntryId="a174-65b4-01d1-f164" minSelections="8" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a174-65b4-01d1-f164" targetId="d990-6016-2e27-d72f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="a991-96fa-4b37-664b" name="Slick with Ensorcelled Blood" hidden="false">
-          <description>If any unit in this formation is withing 18&quot; of the Lord/Kharn, then that unit gets Fleet and Move through Cover. They also add 3&quot; to their charge move.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c086-3c8d-92f5-5490" name="The Chosen of Abaddon" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="f7bf-6bfb-4425-5774" name="Chaos Lord or Sorceror" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="98f6-25ce-5b61-9475" targetId="598f-3cba-b8c5-e748" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7a83-a81f-b1eb-ff24" targetId="9832-6438-ea96-d6d6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="380f-35b3-09c6-c657" name="Chosen or Terminators" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="e922-3b77-646f-ed2c" name="Chosen" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="ec11-5ec1-035f-73d2" targetId="d553-752e-86d1-19fd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="94e2-0fb9-6a2a-a88b" name="Terminators" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="b9da-935c-8cca-50d9" targetId="8a3b-80c7-0cf3-e044" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="minSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="c086-3c8d-92f5-5490" incrementChildId="f7bf-6bfb-4425-5774" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="c086-3c8d-92f5-5490" incrementChildId="f7bf-6bfb-4425-5774" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="be06-6bd2-ffbb-9a68" name="Blessed by the Chaos Gods" hidden="false">
-          <description>Each Lord or sorceror starts the battle with 1 chaos boon. Roll separately for each character.</description>
-          <modifiers/>
-        </rule>
-        <rule id="1db7-1720-cef0-7994" name="Protect the Despoiler" hidden="false">
-          <description>Any unit in this formation within 12&quot; of Abaddon gets Fearless.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="59dd-b91c-e600-c7c3" name="The Hounds of Huron" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="cef4-04ae-b218-ecc1" name="Chaos Bikers" defaultEntryId="d369-295a-5260-c46a" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d369-295a-5260-c46a" targetId="101f-b7b9-83a0-d998" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="b39c-90e5-6cdc-125d" name="Lightning strike" hidden="false">
-          <description>The Chaos Lord and all other units in the formation within 12&quot;of him may charge even if they have Turbo-boosted during that turn.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="882f-06e1-db28-3792" targetId="aa22-0c2c-4620-bcab" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="afb3-c45e-3fa8-b3a5" targetId="7bae-917a-2bad-1ca4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f935-acd9-e443-9397" targetId="598f-3cba-b8c5-e748" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ab61-76b2-4ab0-b7c9" name="Trinity of Blood" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="6a8b-0c9f-e3fe-1ef5" name="Khorne Lord of Skulls" defaultEntryId="e63d-3272-b550-9503" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e63d-3272-b550-9503" targetId="0ef1-079d-c3b9-4bd0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="ac13-5f3f-8a3a-f1e4" name="Cloud of Fury" hidden="false">
-          <description>At the beginning of the Assault phase, all non-vehicle units within 12&quot; of this formation gain Rage</description>
-          <modifiers/>
-        </rule>
-        <rule id="4ffb-e8c7-27ab-7363" name="Wounds in the World" hidden="false">
-          <description>Once per game: At the beginning of your opponents movement phase, declare to use this ability.
-
-All enemy models within 24&quot; of the formation must take a dangerous terrain test during their movement that phase. 
-
-Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures and Super Heavy Fliers), Skimmers, Jump Infanty, Jet Pack Infantry and Jetbikes are not affected by this ability.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
     <entry id="2c93-74cb-4b9d-42c2" name="Abaddon the Despoiler" points="265.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="f158-5a00-fa01-9c26" name="Drach&apos;nyen" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -10877,391 +10271,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
       <links/>
     </entry>
     <entry id="101f-b7b9-83a0-d998" name="Chaos Bikers" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-      <entries>
-        <entry id="9eba-8a34-0c58-cc01" name="Chaos Biker Champion" points="30.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="1aa7-829d-450f-f43d" name="Gift of Mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5cb4-1880-2051-dcba" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="0532-dd8d-81d3-d1f9" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3396-6479-625f-bc0c" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="6e18-572e-cb15-5998" name="Krak Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9037-66dc-812c-8ce6" targetId="530bb69e-c246-fccd-1688-f1cfba50c251" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="cd39-1304-8be9-b179" name="Frag Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="60a9-2b06-1169-9d9e" targetId="59323c0b-e16f-e72a-273d-ca3bb30d53b7" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="953b-4020-221e-a0a5" name="CCW Arm" defaultEntryId="580d-df4c-74ba-60b6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="580d-df4c-74ba-60b6" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f66f-5c07-93f3-f839" targetId="2df1e9cd-8cf9-c4ca-7c0a-0fdb8d8ef2c7" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="fa37-3420-42cf-76b9" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="5757-7862-69d6-228b" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d9c7-12c2-7c39-82bd" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f7fd-e5f1-724a-1bbb" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="b1cc-647a-87ca-6c03" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="a558-cf19-689f-87cc" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="3eca-23ac-6421-a803" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="8e42-4bf8-3bb0-2146" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="7839-c820-4bac-be27" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="5928-afff-0b8c-13d8" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="f4a4-dafe-1a2c-7d4d" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="63d5-7bd4-6b40-4d4f" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="55e7-ceec-61fc-07fa" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="20fb-3b68-2827-0e6e" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="0952-a9d6-d7ba-cf63" name="Bolt Pistol Arm" defaultEntryId="9950-dd89-d485-ec6b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="9950-dd89-d485-ec6b" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="9db8-6744-3b29-b0bd" targetId="a243616a-65df-2af8-f12c-8657bdee994f" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="3078-bf66-9746-0316" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6f9f-3b54-2c48-ab7a" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="f005-bbb6-4f31-4f05" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="721f-07b6-6c0b-125c" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="c542-0a8b-ebe1-0641" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="692f-653e-e033-ac8e" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="509c-a3fe-fb56-4d3e" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="005c-9ded-5222-f726" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1fe0-2534-cef0-d52e" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="c732-d482-48bb-9aba" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="6e91-ec7c-4725-c7ff" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="42dc-5ff8-8d9e-33fc" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d216-3e6e-4948-e575" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f2b1-1282-e650-c178" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="8994-cb5a-1f2c-dc4b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Chaos Biker Champion" hidden="false" page="0">
-              <characteristics>
-                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Bike (Character)"/>
-                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
-                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
-                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
-                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
-                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
-                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
-                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
-                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="101f-b7b9-83a0-d998" childId="09ff-2031-410c-5268" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="101f-b7b9-83a0-d998" childId="634a-a288-a1c4-3ee6" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="101f-b7b9-83a0-d998" childId="1560-4aab-89a5-ba08" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links>
-            <link id="5bbd-bce3-4a29-63ec" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8392-d96f-8480-b94c" name="Chaos Biker" points="20.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="5d18-0e02-37e0-ca9f" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="89cd-d0b9-6465-3302" targetId="2df1e9cd-8cf9-c4ca-7c0a-0fdb8d8ef2c7" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="06c8-3f3e-752a-a890" name="Frag Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3987-8519-33d5-153a" targetId="59323c0b-e16f-e72a-273d-ca3bb30d53b7" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="70f8-a7b2-99ae-578f" name="Krak Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3763-0889-c5c7-cbd2" targetId="530bb69e-c246-fccd-1688-f1cfba50c251" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="ed84-c03c-6616-a1db" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Chaos Biker" hidden="false" page="0">
-              <characteristics>
-                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Bike"/>
-                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
-                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
-                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
-                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
-                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
-                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
-                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
-                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="101f-b7b9-83a0-d998" childId="09ff-2031-410c-5268" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="101f-b7b9-83a0-d998" childId="634a-a288-a1c4-3ee6" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="101f-b7b9-83a0-d998" childId="1560-4aab-89a5-ba08" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
+      <entries/>
       <entryGroups>
         <entryGroup id="8dd6-ad68-f221-bdb7" name="Special Weapons" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
@@ -11313,11 +10323,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           <links>
             <link id="0332-a911-359d-c08f" targetId="d71dd962-cb90-0dd4-e165-462ae8e62e52" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="8392-d96f-8480-b94c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="9eba-8a34-0c58-cc01" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="d6d3-78d9-8772-f76a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -11325,11 +10331,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             </link>
             <link id="09ff-2031-410c-5268" targetId="52cc9914-74e2-a061-cc1e-30e1e08948f3" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="9eba-8a34-0c58-cc01" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="8392-d96f-8480-b94c" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="d6d3-78d9-8772-f76a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -11337,11 +10339,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             </link>
             <link id="634a-a288-a1c4-3ee6" targetId="1af8f61d-fc6c-9508-4a81-c5d8730ec8c8" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="9eba-8a34-0c58-cc01" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="8392-d96f-8480-b94c" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="d6d3-78d9-8772-f76a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -11349,11 +10347,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             </link>
             <link id="2ad7-2506-54f2-ed12" targetId="68928713-5871-66c8-3b3d-e0c69217216a" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="8392-d96f-8480-b94c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="9eba-8a34-0c58-cc01" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="d6d3-78d9-8772-f76a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -11408,6 +10402,359 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             </link>
           </links>
         </entryGroup>
+        <entryGroup id="d6d3-78d9-8772-f76a" name="Unit Size: 3-10" defaultEntryId="ae74-1073-c111-a3e6" minSelections="3" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="9199-5ad7-96da-799a" name="Chaos Biker Champion" points="30.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries>
+                <entry id="dfec-69be-0ccd-6cd5" name="Gift of Mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="675c-c44a-a354-eabb" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="c851-3955-573a-03d2" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="e405-79ca-d620-5e9d" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="0e55-cb8e-47bd-d439" name="Krak Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="33ef-98d9-f5fa-0959" targetId="530bb69e-c246-fccd-1688-f1cfba50c251" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="e5a5-6eb0-7e55-08ec" name="Frag Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="1e0f-4cb0-964d-9480" targetId="59323c0b-e16f-e72a-273d-ca3bb30d53b7" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups>
+                <entryGroup id="d0f6-7cfb-88ad-045c" name="CCW Arm" defaultEntryId="a2ea-0690-f2a9-b266" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="a2ea-0690-f2a9-b266" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="ecbd-8355-ba0b-7d6c" targetId="2df1e9cd-8cf9-c4ca-7c0a-0fdb8d8ef2c7" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="b111-1f6e-09ad-a29d" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="d381-8600-6afa-173b" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="7fea-d19b-eafb-88dc" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="b6be-618a-fb56-fd95" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="b7cc-f23d-4bff-b2a7" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="0163-1375-d5bc-bf27" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="aca2-33b4-5fa7-4b74" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="9b65-eb52-df7a-f5af" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="96ac-034e-9d56-8a2e" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="aff5-424d-348a-4bb7" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="e30a-45d0-9ba6-1644" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="aa4a-5c56-cb2e-16b1" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="6c27-4fc6-63ca-3da5" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="f713-8373-9f3d-0b67" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+                <entryGroup id="a836-77a3-aaa5-9862" name="Bolt Pistol Arm" defaultEntryId="fb04-42e7-513a-8a21" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="fb04-42e7-513a-8a21" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="a24a-890d-2ce2-e1d1" targetId="a243616a-65df-2af8-f12c-8657bdee994f" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="9910-e531-b9b6-9ef5" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="e0d1-31fb-03ad-2269" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="9539-fd16-cda6-1a24" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="3262-3b6f-27c8-c0b3" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="1b1b-cf35-54aa-136d" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="b839-00ee-8123-b302" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="b18a-e6dc-5e65-c2c6" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="6bcc-2315-d140-d6e0" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="eef6-fe1e-1872-d7e5" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="cb45-e2d7-7ef6-6651" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="5464-a658-a288-6174" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="4eea-ec4f-ca63-9e56" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="cf26-cbab-c2df-e3f7" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="c7a6-992e-3822-ed66" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="83bd-4322-e8f1-77aa" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Chaos Biker Champion" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Bike (Character)"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+                  </characteristics>
+                  <modifiers>
+                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="101f-b7b9-83a0-d998" childId="09ff-2031-410c-5268" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="101f-b7b9-83a0-d998" childId="634a-a288-a1c4-3ee6" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="101f-b7b9-83a0-d998" childId="1560-4aab-89a5-ba08" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                </profile>
+              </profiles>
+              <links>
+                <link id="cd3d-dc33-131a-6bb9" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="ae74-1073-c111-a3e6" name="Chaos Biker" points="20.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="a39c-b62f-8e67-48e3" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Chaos Biker" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Bike"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+                  </characteristics>
+                  <modifiers>
+                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="101f-b7b9-83a0-d998" childId="09ff-2031-410c-5268" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="101f-b7b9-83a0-d998" childId="634a-a288-a1c4-3ee6" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="101f-b7b9-83a0-d998" childId="1560-4aab-89a5-ba08" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -11415,11 +10762,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
       <links>
         <link id="1560-4aab-89a5-ba08" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
           <modifiers>
-            <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="9eba-8a34-0c58-cc01" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="8392-d96f-8480-b94c" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="101f-b7b9-83a0-d998" incrementChildId="d6d3-78d9-8772-f76a" incrementField="selections" incrementValue="1.0">
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -11428,56 +10771,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
       </links>
     </entry>
     <entry id="b9a9-557f-f8fb-4377" name="Chaos Cultists" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-      <entries>
-        <entry id="114f-8e07-c403-cc9c" name="Cultist Champion" points="14.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="3eaa-0f6d-afcc-58d0" name="Shotgun" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3c30-a763-28a0-cc71" targetId="818d57df-1978-6aba-ae9b-6812fd06a571" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="9120-3139-dd86-4ac6" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="14ad-7a03-57bc-b791" name="Auto Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="554c-da82-f051-881d" targetId="dbb38ee5-37f3-24ec-c20b-2085701907fc" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a643-b81f-35c4-6c6d" targetId="1437ed6e-83fd-dc94-8370-0bbf6961b6b7" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="b867-14c8-d500-772e" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
+      <entries/>
       <entryGroups>
         <entryGroup id="f7e5-4901-3488-7f28" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
@@ -11554,7 +10848,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="a7c1-38d8-3fc3-beb8" name="Unit Size: 10 - 35 models" defaultEntryId="d755-e33b-3430-b3a6" minSelections="9" maxSelections="34" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="a7c1-38d8-3fc3-beb8" name="Unit Size: 10 - 35 models" defaultEntryId="d755-e33b-3430-b3a6" minSelections="10" maxSelections="35" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="e620-240c-83af-3044" name="Heavy Weapon Cultist" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
@@ -11666,6 +10960,54 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                   <modifiers/>
                 </link>
                 <link id="d648-d95b-9baf-537e" targetId="6699ba42-bdf8-38d2-d108-bf4956309027" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3be0-01bb-80f7-1094" name="Cultist Champion" points="14.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries>
+                <entry id="f3f4-dcba-81dc-3bcf" name="Shotgun" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="6c14-ff2d-375f-f92d" targetId="818d57df-1978-6aba-ae9b-6812fd06a571" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="7109-4c7c-521b-b4f6" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links/>
+                </entry>
+                <entry id="b83b-f355-6e43-5e6d" name="Auto Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="12a9-a91a-b603-d37f" targetId="dbb38ee5-37f3-24ec-c20b-2085701907fc" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b54c-5b0c-93eb-02b9" targetId="1437ed6e-83fd-dc94-8370-0bbf6961b6b7" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="1898-5d68-c6fc-6b3e" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
                   <modifiers/>
                 </link>
               </links>
@@ -12171,7 +11513,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           <modifiers>
             <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="598f-3cba-b8c5-e748" childId="6361-4913-97b7-e2cf" field="selections" type="at least" value="1.0"/>
+                <condition parentId="598f-3cba-b8c5-e748" childId="89a1-e676-5224-1b3a" field="selections" type="equal to" value="0.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -12267,9 +11609,9 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           </entries>
           <entryGroups/>
           <modifiers>
-            <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="598f-3cba-b8c5-e748" childId="6361-4913-97b7-e2cf" field="selections" type="at least" value="1.0"/>
+                <condition parentId="598f-3cba-b8c5-e748" childId="6361-4913-97b7-e2cf" field="selections" type="equal to" value="0.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -12385,9 +11727,9 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           </entries>
           <entryGroups/>
           <modifiers>
-            <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="598f-3cba-b8c5-e748" childId="6361-4913-97b7-e2cf" field="selections" type="at least" value="1.0"/>
+                <condition parentId="598f-3cba-b8c5-e748" childId="6361-4913-97b7-e2cf" field="selections" type="equal to" value="0.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -12488,6 +11830,12 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           </modifiers>
         </link>
         <link id="2ff0-5814-0355-1a61" targetId="9fdf9687-7daa-1ae2-8c3f-36e3ad3ed0dc" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="ea65-678f-b743-b95b" targetId="530bb69e-c246-fccd-1688-f1cfba50c251" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="a14a-28e7-7a94-b436" targetId="59323c0b-e16f-e72a-273d-ca3bb30d53b7" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -13191,7 +12539,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                 </modifier>
                 <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="force type" childId="3112-8055-b691-9851" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="force type" childId="3112-8055-b691-9851" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -13205,7 +12553,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                 </modifier>
                 <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="force type" childId="3112-8055-b691-9851" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="force type" childId="3112-8055-b691-9851" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -13219,7 +12567,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                 </modifier>
                 <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="force type" childId="3112-8055-b691-9851" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="force type" childId="3112-8055-b691-9851" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -13451,7 +12799,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                 </entry>
               </entries>
               <entryGroups>
-                <entryGroup id="4d4f-3bca-1c76-378c" name="Ranged Weapons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="4d4f-3bca-1c76-378c" name="Ranged Weapons" defaultEntryId="b4fb-4e27-bccb-debf" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="b4fb-4e27-bccb-debf" name="Boltgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                       <entries/>
@@ -14134,7 +13482,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             <entry id="9cb6-110c-a6c8-fb06" name="Terminator" points="31.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups>
-                <entryGroup id="116e-7c5d-7e02-6c1f" name="Melee Weapon Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="116e-7c5d-7e02-6c1f" name="Melee Weapon Arm" defaultEntryId="55f8-6f9a-351a-273e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="55f8-6f9a-351a-273e" name="Power Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                       <entries/>
@@ -14189,7 +13537,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="fae2-c667-cffe-3287" name="Ranged Weapon arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="fae2-c667-cffe-3287" name="Ranged Weapon arm" defaultEntryId="c664-6749-f2d8-3aac" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="c664-6749-f2d8-3aac" name="Combi-Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                       <entries/>
@@ -14244,7 +13592,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             <entry id="72d9-e572-1f57-cd57" name="Terminator with Heavy Weapon" points="31.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups>
-                <entryGroup id="3688-4a75-097d-3b7a" name="Heavy Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="3688-4a75-097d-3b7a" name="Heavy Weapon" defaultEntryId="1107-dd5e-f548-fcc0" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="10d2-80cd-fae1-411f" name="Reaper Autocannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
@@ -14275,7 +13623,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="9330-2b9c-fc3c-5a26" name="Melee Weapon Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="9330-2b9c-fc3c-5a26" name="Melee Weapon Arm" defaultEntryId="2939-84e1-d975-cc95" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="2939-84e1-d975-cc95" name="Power Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                       <entries/>
@@ -14365,7 +13713,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                 </entry>
               </entries>
               <entryGroups>
-                <entryGroup id="fe3b-4c01-d010-66eb" name="Terminator CCW" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="fe3b-4c01-d010-66eb" name="Terminator CCW" defaultEntryId="b59b-6d63-b238-840f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="b59b-6d63-b238-840f" name="Power Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
@@ -14420,7 +13768,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="bc24-fe0a-eea1-97f0" name="Terminator ranged weapons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="bc24-fe0a-eea1-97f0" name="Terminator ranged weapons" defaultEntryId="7cfb-8182-f228-4557" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="dbfd-e558-2e64-345c" name="Combi-Weapon" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
@@ -15709,113 +15057,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
       </links>
     </entry>
     <entry id="d553-752e-86d1-19fd" name="Chosen" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-      <entries>
-        <entry id="3e5e-20df-a152-1981" name="Chosen Champion" points="18.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="3e92-cd80-74c6-b979" name="Melta Bomb" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="fb64-f640-977a-882b" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="db15-c409-2eda-89e4" name="Gift of mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="057e-0b8f-657d-20bc" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="ad41-4d68-9bd2-2553" name="Boltgun options" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="5ec6-02af-656d-66a7" name="Boltgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="17a4-cad8-7048-598d" targetId="8b2113df-55b3-2f62-0601-f729b5851ac0" linkType="profile">
-                      <modifiers/>
-                    </link>
-                    <link id="6b1c-d71f-537b-8e9b" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="category" childId="c086-3c8d-92f5-5490" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles>
-            <profile id="cec4-e318-0e0b-60a4" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Chosen Champion" hidden="false" page="0">
-              <characteristics>
-                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
-                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
-                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
-                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
-                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
-                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
-                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
-                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
-                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d553-752e-86d1-19fd" childId="2fa5-1c0d-0825-0f8a" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d553-752e-86d1-19fd" childId="b379-aff2-cd34-b956" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d553-752e-86d1-19fd" childId="2fc8-462c-b6cd-a4cc" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links>
-            <link id="f2fd-099d-1c2b-1a34" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0853-86d7-26c6-6496" targetId="c08263bd-fddb-134f-7bdb-f04b39af1e2f" linkType="entry group">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
+      <entries/>
       <entryGroups>
         <entryGroup id="ddcd-6fab-3aa8-6f92" name="Chaos Icon" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -15867,15 +15109,18 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
         <entryGroup id="3b08-49f9-d98a-c0b9" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="direct parent" childId="7ca4-ddc1-cfc2-8276" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <links>
             <link id="1ef9-cbd0-8352-bf8f" targetId="d71dd962-cb90-0dd4-e165-462ae8e62e52" linkType="entry">
               <modifiers>
                 <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="48a4-8243-ec18-f45f" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="3e5e-20df-a152-1981" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -15887,19 +15132,11 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="3e5e-20df-a152-1981" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
               </modifiers>
             </link>
             <link id="b379-aff2-cd34-b956" targetId="1af8f61d-fc6c-9508-4a81-c5d8730ec8c8" linkType="entry">
               <modifiers>
                 <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="48a4-8243-ec18-f45f" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="3e5e-20df-a152-1981" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -15911,15 +15148,11 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="3e5e-20df-a152-1981" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
               </modifiers>
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="48a4-8243-ec18-f45f" name="Unit size: 5-10 models" defaultEntryId="c020-39ca-513c-07a0" minSelections="4" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="48a4-8243-ec18-f45f" name="Unit size: 5-10 models" defaultEntryId="c020-39ca-513c-07a0" minSelections="5" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="c020-39ca-513c-07a0" name="Chosen with Boltgun, CCW and Boltpistol" points="18.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -15928,6 +15161,111 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
               <rules/>
               <profiles/>
               <links/>
+            </entry>
+            <entry id="46fd-2ce2-ce4c-b292" name="Chosen Champion" points="18.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries>
+                <entry id="c9e4-52f0-c0b1-a3fd" name="Melta Bomb" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="effc-cde1-5971-9c26" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="fcaf-7cae-ee48-e07a" name="Gift of mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="2a02-c871-88ec-dc8e" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups>
+                <entryGroup id="e1c0-fc30-e73c-9acf" name="Boltgun options" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="731e-2429-5d89-e0f7" name="Boltgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="f554-b16d-ae1e-2f28" targetId="8b2113df-55b3-2f62-0601-f729b5851ac0" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="47db-9a73-d4ab-f94e" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers>
+                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="category" childId="c086-3c8d-92f5-5490" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles>
+                <profile id="e4f1-f6eb-7bdc-00f4" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Chosen Champion" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+                  </characteristics>
+                  <modifiers>
+                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d553-752e-86d1-19fd" childId="2fa5-1c0d-0825-0f8a" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d553-752e-86d1-19fd" childId="b379-aff2-cd34-b956" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d553-752e-86d1-19fd" childId="2fc8-462c-b6cd-a4cc" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                </profile>
+              </profiles>
+              <links>
+                <link id="d425-a94a-9307-e132" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="b044-2512-0253-01f8" targetId="c08263bd-fddb-134f-7bdb-f04b39af1e2f" linkType="entry group">
+                  <modifiers/>
+                </link>
+              </links>
             </entry>
           </entries>
           <entryGroups>
@@ -16236,21 +15574,38 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
       </profiles>
       <links>
         <link id="4857-b89d-829a-aa13" targetId="92082917-801e-6a7c-2d3e-c14721c244bc" linkType="entry">
-          <modifiers/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="direct parent" childId="7ca4-ddc1-cfc2-8276" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
         <link id="fc1c-035e-1f9e-7a5d" targetId="6ccbaf25-07e9-ce90-84fa-a0155a26ff0f" linkType="entry">
-          <modifiers/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="direct parent" childId="7ca4-ddc1-cfc2-8276" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
         <link id="e3f7-bc5a-4a11-9d5c" targetId="a5dbfed5-7768-9674-4650-71a5c5103417" linkType="entry">
-          <modifiers/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="direct parent" childId="7ca4-ddc1-cfc2-8276" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
         <link id="2fc8-462c-b6cd-a4cc" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
           <modifiers>
             <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="48a4-8243-ec18-f45f" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d553-752e-86d1-19fd" incrementChildId="3e5e-20df-a152-1981" incrementField="selections" incrementValue="1.0">
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -16293,6 +15648,249 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
         </profile>
       </profiles>
       <links/>
+    </entry>
+    <entry id="be3e-2b76-2fc2-46ce" name="Cult of Destruction" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
+      <entries>
+        <entry id="961c-61c6-5929-c4aa" name="Obliterator Units" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="7cda-6ee0-93d9-0920" name="Obliterators" points="70.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="d5d7-f87b-46d6-80ae" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="fb79-b8de-205d-ee3a" name="Mark of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <rules/>
+                  <profiles/>
+                  <links/>
+                </entry>
+                <entry id="7d6a-a418-0433-0ccf" name="Mark of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="8.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <rules/>
+                  <profiles/>
+                  <links/>
+                </entry>
+                <entry id="8ec0-2fa7-cbc9-d6f0" name="Mark of Nurgle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <rules/>
+                  <profiles/>
+                  <links/>
+                </entry>
+                <entry id="874d-da5c-1dde-1e38" name="Mark of Slaanesh" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <rules/>
+                  <profiles/>
+                  <links/>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="556a-3e33-63fe-689a" targetId="8716278e-3703-03c2-1f2c-f9b4f243155c" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="4a8e-b8ef-bfff-a098" targetId="1e872ce3-4417-cd8f-5516-ccd120a2b36c" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="6a92-8767-da10-38d1" targetId="6fa0c91c-6324-f45e-ad42-620666a28e9d" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="8456-826a-23c7-c45d" targetId="65fc22df-1d64-cf1b-8e97-f9a44fbc0114" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="e084-3f82-65b9-6a0f" targetId="10c2dc32-e122-a91a-2071-0dffec452951" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="58f4-6b86-f639-dbae" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
+              <modifiers>
+                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="961c-61c6-5929-c4aa" incrementChildId="7cda-6ee0-93d9-0920" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="9e72-cdbb-207f-d981" name="Mutilator Units" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="5494-8794-0ede-a889" name="Mutilators" points="55.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups>
+                <entryGroup id="50d5-2447-efd3-0477" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="9cee-b38a-3855-e8a1" name="Mark of Khorne" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links/>
+                    </entry>
+                    <entry id="197b-112d-74b3-5a4a" name="Mark of Tzeentch" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links/>
+                    </entry>
+                    <entry id="9691-3733-5fdb-1de7" name="Mark of Nurgle" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links/>
+                    </entry>
+                    <entry id="9166-e6ac-3ea1-c5aa" name="Mark of Slaanesh" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links/>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="39a6-745e-3c4a-ccd4" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="fc10-3e12-aeec-d6a5" targetId="57e9f954-ec4a-1bfc-359d-e59d9e1f92a2" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="3337-6411-6028-abe2" targetId="65fc22df-1d64-cf1b-8e97-f9a44fbc0114" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="40b8-4446-d0a1-1cd7" targetId="24a441c3-9970-5437-cfab-db3e08852f98" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="b967-d220-b5b8-89cf" targetId="1e872ce3-4417-cd8f-5516-ccd120a2b36c" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="5bc2-f36a-e8a3-ef95" targetId="8716278e-3703-03c2-1f2c-f9b4f243155c" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="aa23-3fb0-9730-028a" targetId="bf115a80-562e-f171-648e-8f8af04da18b" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="7f54-d953-a8c2-180c" name="Engines of Destruction" hidden="false">
+          <description>Six or  more Obliterators in  the fo rmation can  combine their shooting attacks  into  a 
+single  attack  using one of  the prof iles below. All of  the  Obliterators that participate 
+must be in range  and have line  of sight to the  target. 
+LAS - DESTRUCTOR 
+Range  S  AP  Type 
+D  1  Heavy  1, 
+HELLFLAME 
+Range  S  AP  Type 
+Hellstorm  5  3  Assault 1 
+SHELLSTORM 
+Range  S  AP  Type 
+5  4  Assault 1, 
+Apocalyptic Blast </description>
+          <modifiers/>
+        </rule>
+        <rule id="2535-1576-108a-74f5" name="Orgy of Devastation" hidden="false">
+          <description>Mutilators in the formation have the Furious Charge special rule. Furthermore, for every unsaved Wound caused  by a Mutilator in the formati on, the Mutilator immediately makes an additional Attack.  These extra Attacks cannot generate further additional Attacks. </description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="bf0e-b287-50b6-1332" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Las-Destructor" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="4945-38c5-b949-65f0" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Hellflame" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Hellstorm"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="17d0-eb7c-78ca-71ae" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Shellstorm" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Apocalyptic Blast"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7e28-a297-5915-38ab" targetId="7cdf7d7e-8e25-5903-e18c-72b82b90eaae" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="b73e-1f6c-89d6-165e" name="Cypher" points="190.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Dataslate: Cypher" page="0">
       <entries>
@@ -16563,7 +16161,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="8556-b7c0-b028-50d4" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="8556-b7c0-b028-50d4" name="Weapon" defaultEntryId="fce8-54c1-b14f-7901" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="fce8-54c1-b14f-7901" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -16651,10 +16249,42 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
         <link id="e0c7-ec2b-a709-807d" targetId="9fdf9687-7daa-1ae2-8c3f-36e3ad3ed0dc" linkType="entry">
           <modifiers/>
         </link>
-        <link id="f872-4818-77d4-439b" targetId="9fdf9687-7daa-1ae2-8c3f-36e3ad3ed0dc" linkType="entry">
-          <modifiers/>
-        </link>
       </links>
+    </entry>
+    <entry id="17f4-9b8e-8684-fbfe" name="Daemon-Engine Hunting Pack" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="0aff-d2aa-7b6e-2bee" name="Fiends" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="67b4-8831-f550-a51d" targetId="ac6d-d083-8ae2-dc18" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="d906-55c4-03e6-9695" targetId="a374-0611-5092-b88b" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="0d70-c046-82b6-eb5f" name="Hunting Pack" hidden="false">
+          <description>After deployment, but before the first turn, nominate one character model int eh enemy army. All vehicles in the spearhead have the Preferred Enemy rule when attacking this model. In addition, if the nominated enemy model is destroyed, the side this formation belongs to scores 1 Strategic Victory Point.</description>
+          <modifiers/>
+        </rule>
+        <rule id="92b6-d646-8f8d-f982" name="Prized Possessions" hidden="false">
+          <description>At the start of the battle, you may nominate one Chaos Warpsmith in the same army to be the Daemon Engine Pack&apos;s owner. Any models from this formation that are within 12&quot; of the owner may use his WS and BS instead of their own.</description>
+          <modifiers/>
+        </rule>
+        <rule id="c238-177c-0266-8c6d" name="Thunderous Charge" hidden="false">
+          <description>If the spearhead is in Rapier Attack Pattern, it may charge even if it Ran in the Shooting phase.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="41a01875-4e12-9eee-006f-792647f9d9e5" name="Daemonheart" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" page="0">
       <entries/>
@@ -16700,7 +16330,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
         </entry>
       </entries>
       <entryGroups>
-        <entryGroup id="816f-e029-35de-2102" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="816f-e029-35de-2102" name="Ranged Weapon" defaultEntryId="f40a-a178-83cd-3a10" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="f40a-a178-83cd-3a10" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -16757,7 +16387,7 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="7c04-0505-5280-0f65" name="Close Combat Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="7c04-0505-5280-0f65" name="Close Combat Weapon" defaultEntryId="264f-c85c-73dc-f5fa" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="264f-c85c-73dc-f5fa" name="Power Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -16881,6 +16511,12 @@ Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures
           <modifiers/>
         </link>
         <link id="ef0e-9c8b-4db4-0105" targetId="7bda-7c33-ecff-a43a" linkType="entry group">
+          <modifiers/>
+        </link>
+        <link id="3ebc-e5ce-d81d-83f9" targetId="59323c0b-e16f-e72a-273d-ca3bb30d53b7" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="97b1-6a30-d2ba-73e5" targetId="530bb69e-c246-fccd-1688-f1cfba50c251" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -17324,6 +16960,38 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
         </link>
       </links>
     </entry>
+    <entry id="7ca4-ddc1-cfc2-8276" name="Fallen Champions" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Cypher" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="dffb-47ef-464b-fd4c" name="Chosen" defaultEntryId="7dbf-88ee-227e-bb59" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="7dbf-88ee-227e-bb59" targetId="d553-752e-86d1-19fd" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="bcf7-34b8-b586-4f49" name="Fallen Leader" hidden="false">
+          <description>Any unit f rom this Formation that is within 12&quot; of  Cypher must use his Leadership characteristic instead of  their own for any Leadership tests,  and has the And They Shall Know No Fear special rule.</description>
+          <modifiers/>
+        </rule>
+        <rule id="c518-0162-7f54-dc9f" name="Never Forgive" hidden="false">
+          <description>In missions that include both Cypher and Dark Angels models, all Dark Angels models with the Inner Circle special rule also receive the Zealot special rule.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="4f38-6db7-e2da-8d3c" targetId="b73e-1f6c-89d6-165e" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="1169ef3a-e3ba-35c4-1199-eb24b8d2b3ce" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Shield of Baal: Leviathan">
       <entries/>
       <entryGroups/>
@@ -17426,517 +17094,8 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
         </link>
       </links>
     </entry>
-    <entry id="7ca4-ddc1-cfc2-8276" name="Fallen Champions" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Cypher" page="0">
-      <entries>
-        <entry id="6e33-a27b-b804-3ce2" name="Chosen" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9127-255f-5788-fea7" targetId="d553-752e-86d1-19fd" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="db98-e604-ece7-a165" name="Cypher" points="190.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Cypher" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="539f-bb76-6e6c-d8e6" targetId="b73e-1f6c-89d6-165e" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b345-493e-9046-8f93" name="Helcult" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Helbrutes" page="0">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="f4fa-10b7-0e31-0ca7" name="Chaos Cultists" defaultEntryId="7490-ed47-694e-f86e" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7490-ed47-694e-f86e" targetId="b9a9-557f-f8fb-4377" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="minSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="minSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f605-1a30-0ba8-fe26" name="Helbrute" defaultEntryId="4c0f-5e1d-d4a7-d34f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4c0f-5e1d-d4a7-d34f" targetId="c3c4-425d-e94e-1b26" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="3a36-20e8-fb38-6864" name="Apocalyptic Fury" hidden="false" page="0">
-          <description>The Helbrute has Rage. When rolling to hit with the Helbrute&apos;s Melee attacks, any unmodified rolls of a 1 hit a friendly model instead. Randomly determine (for each roll of a 1) which models within 6&quot; of the Helbrute are hit instead.</description>
-          <modifiers/>
-        </rule>
-        <rule id="db3f-ddcb-2d0a-ab55" name="Living Idol of Chaos" hidden="false" page="0">
-          <description>As long as the Helbrute is alive, the Cultists have Fearless. If the Helbrute is destroyed, the cultists lose Fearless and gain Zealot.</description>
-          <modifiers/>
-        </rule>
-        <rule id="420a-ae67-2996-96d9" name="Human Shields" hidden="false" page="0">
-          <description>If the Helbrute is partially obscured from one or more of the formations cultists, it recieves a 3+ Cover save but a model from the cultist unit is removed (without saves) for each successful save as a result of this rule.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="ad0c-fa4b-a960-a007" name="Helfist Murderpack" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Helbrutes" page="0">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="bb82-3c72-9efd-272c" name="Helbrutes" minSelections="5" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3561-8d15-7b43-5fbf" targetId="c3c4-425d-e94e-1b26" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="minSelections" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="bc6c-fb0c-6974-9ad8" name="Murderpack" hidden="false" page="0">
-          <description>All Helbrutes in this formation count as a single Vehicle Squadron</description>
-          <modifiers/>
-        </rule>
-        <rule id="82da-bdff-8ab0-7fb2" name="Pack Leader" hidden="false" page="0">
-          <description>The Helbrute Champion has the Vehicle (Character) unit type and the Aura of Dark Glory. If the Helbrute champion is still alive, the controlling player may chose what the crazed result for ALL Helbrutes in the formation instead of rolling (the crazed result is the same for all the Helbrutes).</description>
-          <modifiers/>
-        </rule>
-        <rule id="a44b-ee2b-24b4-f288" name="Death of a Leader" hidden="false" page="0">
-          <description>IF the Helbruite Champion is destroyed, all other Helbrutes gain Rage.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="3112-8055-b691-9851" name="Kharn&apos;s Butcherhorde" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4345-cad3-50fb-b148" name="Chaos Space Marines" defaultEntryId="71ec-88b7-227a-00df" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="71ec-88b7-227a-00df" targetId="3354-24e9-4ec9-506b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="2c2f-67c4-e202-4a71" name="Khorne Berzerkers" defaultEntryId="a88b-6e72-bbf8-c3ce" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a88b-6e72-bbf8-c3ce" targetId="d990-6016-2e27-d72f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c7c8-c02f-9706-511a" name="Kharn the Betrayer" defaultEntryId="7713-0b9b-f464-f577" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7713-0b9b-f464-f577" targetId="08ed-5bd1-f1e7-6419" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="d069-69c8-0061-4af1" name="Blood and Rage" hidden="false">
-          <description>When a unit in this formation rolls an 8 for charge range (including re-rolls), then all models in that unit double their attack stat for that turn.</description>
-          <modifiers/>
-        </rule>
-        <rule id="79df-3fd9-61d3-b905" name="Slaughter without Respite" hidden="false">
-          <description>Each time a model in the formation scores a 6 on a to-hit roll, then it gains an extra attack. If additional 6&apos;s are rolled, then these also gain extra attacks.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2160-a7de-6d37-4310" name="Mayhem Pack" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Helbrutes" page="0">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="5fed-5f92-387a-5596" name="Helbrute" defaultEntryId="2625-162b-e101-5264" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2625-162b-e101-5264" targetId="c3c4-425d-e94e-1b26" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="dd30-5462-5ffe-bb32" name="Mayhem from the Maelstrom" hidden="false" page="0">
-          <description>All of the Units in the formation must start in Reserve. When rolling Reserve rolls, roll a single D6 for the entire unit. On a successful Reserve roll, the entire formation arrives via Deep Strike</description>
-          <modifiers/>
-        </rule>
-        <rule id="06a8-478a-f91d-b8ff" name="Tormented Terrors" hidden="false" page="0">
-          <description>At the start of each of your Movement phase, make a single Crazed result roll regardless if the Helbrutes have suffered a Glance or Penetrating hit.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="f129-4bd9-2c67-fbb8" targetId="893e92c2-a4b4-6646-8bac-bfa4ad7a776d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
     <entry id="d8e0-73f9-06d0-347b" name="Havocs" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="8faa-169f-c5de-f089" name="Aspiring Champion" points="23.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="8269-53a1-d8f8-fa33" name="Gift of Mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="8450-bc53-85ea-e036" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="2bd9-da9b-e289-7a26" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e586-9e2f-df03-bb15" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="a0ba-95d4-c604-f5c0" name="Bolt Pistol Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="1d0f-af29-16e7-7a13" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="5162-00fb-bcc9-79be" targetId="a243616a-65df-2af8-f12c-8657bdee994f" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="78f9-750a-db42-f0c6" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6471-9f96-de2c-8aee" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="be4f-2a4c-99ce-becd" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="ec00-7686-0464-666b" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1e17-5d85-1d17-3ad8" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6c48-ad83-a7ea-b781" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="9480-7593-7d8a-f220" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="17bf-b97a-ca17-00a9" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="145a-6f0f-fac8-266d" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="e2e7-f1e1-901a-783c" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="4348-7cb3-1d71-2bda" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="d862-dc54-7f8f-c4d6" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="f53d-f1bc-95cd-a6fb" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="e3f9-cb20-664d-d887" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="0833-0274-a815-7313" name="CCW Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="a1aa-a493-d740-253c" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="bb3a-7467-9b40-6781" targetId="2df1e9cd-8cf9-c4ca-7c0a-0fdb8d8ef2c7" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="9bed-ca21-ce5a-8818" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="1e3d-4cfc-8b8e-4a93" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="cac7-1fcd-7df9-948d" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="c228-ea64-3646-ff62" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1356-2557-803d-5b83" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6347-b82a-d04b-6369" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="fded-ec1e-a741-65ce" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="e204-ddc7-bd89-5ffa" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d6f2-75c0-6f2b-5cc5" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="806e-db0b-0b67-6abe" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="f50b-b0e2-a574-c6c0" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="0519-0343-e4aa-0fe9" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="ed55-daa9-30f9-50c4" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="1649-2d5f-d185-27d3" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="14a8-84cc-06a5-59b3" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Aspiring Champion" hidden="false" page="0">
-              <characteristics>
-                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
-                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
-                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
-                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
-                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
-                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
-                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
-                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
-                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d8e0-73f9-06d0-347b" childId="3096-eb3e-ab92-44ea" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d8e0-73f9-06d0-347b" childId="6f56-0faa-9378-8d77" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d8e0-73f9-06d0-347b" childId="b518-863a-6606-144a" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="da88-bc96-7ac1-090c" name="Havoc" points="13.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="cb34-e14f-3ec0-d6ba" name="Close Combat Weapon" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -17980,11 +17139,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
           <links>
             <link id="705a-ac88-0bae-303e" targetId="d71dd962-cb90-0dd4-e165-462ae8e62e52" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="8faa-169f-c5de-f089" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="da88-bc96-7ac1-090c" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="2e5e-c0db-7a98-3b1a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -17992,11 +17147,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
             </link>
             <link id="3096-eb3e-ab92-44ea" targetId="52cc9914-74e2-a061-cc1e-30e1e08948f3" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="da88-bc96-7ac1-090c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="8faa-169f-c5de-f089" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="2e5e-c0db-7a98-3b1a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -18004,11 +17155,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
             </link>
             <link id="6f56-0faa-9378-8d77" targetId="1af8f61d-fc6c-9508-4a81-c5d8730ec8c8" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="da88-bc96-7ac1-090c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="8faa-169f-c5de-f089" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="2e5e-c0db-7a98-3b1a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -18016,11 +17163,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
             </link>
             <link id="4f43-1edd-0f9a-b387" targetId="68928713-5871-66c8-3b3d-e0c69217216a" linkType="entry">
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="8faa-169f-c5de-f089" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="da88-bc96-7ac1-090c" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="2e5e-c0db-7a98-3b1a" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -18169,6 +17312,319 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
             </link>
           </links>
         </entryGroup>
+        <entryGroup id="2e5e-c0db-7a98-3b1a" name="Unit Size: 5-10" defaultEntryId="0491-11fc-2da2-20c3" minSelections="5" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="635d-0ed9-bc8a-fa36" name="Aspiring Champion" points="23.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries>
+                <entry id="1f68-469c-8932-17d5" name="Gift of Mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="4dd1-7adc-e3f2-6ad9" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="a6da-c754-448b-8cf0" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="e3d0-61bb-a42c-ea9e" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups>
+                <entryGroup id="ea5b-05c4-e3b2-4cb6" name="Bolt Pistol Arm" defaultEntryId="9034-faee-4532-00df" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="9034-faee-4532-00df" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="db80-4cf7-f1ea-3ac9" targetId="a243616a-65df-2af8-f12c-8657bdee994f" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="f451-b56c-2adf-c34e" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="4be1-cb4e-a9f5-d548" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="a401-0e30-4320-9ccc" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="9739-5a2f-260d-1b9a" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="668f-e291-6069-e097" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="26ed-6efa-dbca-9f14" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="d425-ccc1-f8d1-10aa" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="5ca3-0f53-cf6f-e911" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="d561-ca0c-ba52-f19d" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="c3c3-27ec-263f-893c" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="c12a-03ad-250e-e141" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="c408-9257-43d5-ee1e" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="92fa-1464-e4af-68ce" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="7183-6b8a-6ab0-a136" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+                <entryGroup id="fa20-8e12-f21b-ae6c" name="CCW Arm" defaultEntryId="80b3-1a1e-ec6d-9f27" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="80b3-1a1e-ec6d-9f27" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="d0c6-d3fe-9f34-3d52" targetId="2df1e9cd-8cf9-c4ca-7c0a-0fdb8d8ef2c7" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="d792-8877-524b-4bc1" name="Chainaxe" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="dfac-97a8-8e4e-96e2" targetId="9e3c8b24-da22-72e9-f3bd-4841d62386af" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="aeb4-a458-8b04-f0f7" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="b1e9-6728-3f8a-2268" targetId="a4179841-3ef0-1d10-a4ce-af296b0c32da" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="b7eb-2a99-171f-cf08" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="a231-c597-4e62-5c6e" targetId="13cd1159-0937-4d9c-e535-2dcaa71fd742" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="49fa-22f6-612e-835f" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="395a-36fa-b1e5-99c0" targetId="40d66948-d966-cfee-bbec-f78da952dd38" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="2350-3538-ebae-f300" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="6c2b-82a1-5296-4da0" targetId="62ea1bb0-5f89-ed51-362d-9af0930d582e" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="efdc-2e2f-c27b-f486" name="Power Weapon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="44b2-300b-10e0-85bf" targetId="c82b50bc-bbe3-628f-c588-68c25efabb80" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="6064-a02f-aa03-acf4" name="Ranged Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="09a6-eba3-e789-39f1" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="4c02-881f-dab2-f1f7" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Aspiring Champion" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+                  </characteristics>
+                  <modifiers>
+                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d8e0-73f9-06d0-347b" childId="3096-eb3e-ab92-44ea" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d8e0-73f9-06d0-347b" childId="6f56-0faa-9378-8d77" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d8e0-73f9-06d0-347b" childId="b518-863a-6606-144a" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="0491-11fc-2da2-20c3" name="Havoc" points="13.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="06a2-4534-b348-0b48" targetId="9dd4-1962-1bdb-f55a" linkType="profile">
+                  <modifiers>
+                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d8e0-73f9-06d0-347b" childId="3096-eb3e-ab92-44ea" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d8e0-73f9-06d0-347b" childId="b518-863a-6606-144a" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="a558b3ef-04d0-440e-a312-bac3255bf592" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="d8e0-73f9-06d0-347b" childId="6f56-0faa-9378-8d77" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -18214,11 +17670,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
         </link>
         <link id="b518-863a-6606-144a" targetId="d32e5abf-de5b-a35a-beec-cba3220b837f" linkType="entry">
           <modifiers>
-            <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="8faa-169f-c5de-f089" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="da88-bc96-7ac1-090c" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="d8e0-73f9-06d0-347b" incrementChildId="2e5e-c0db-7a98-3b1a" incrementField="selections" incrementValue="1.0">
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -18229,7 +17681,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
     <entry id="c3c4-425d-e94e-1b26" name="Helbrute" points="100.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
-        <entryGroup id="7bae-86a1-5380-6339" name="Range Weapon" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="7bae-86a1-5380-6339" name="Range Weapon" defaultEntryId="e26f-6d58-6baf-f508" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="e26f-6d58-6baf-f508" name="Multi-melta" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -18375,7 +17827,7 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="7c77-c716-18b4-4087" name="Melee Weapon" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="7c77-c716-18b4-4087" name="Melee Weapon" defaultEntryId="bc7f-b5f6-fc59-ac86" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="bc7f-b5f6-fc59-ac86" name="Power fist" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries>
@@ -18482,6 +17934,48 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
         </link>
       </links>
     </entry>
+    <entry id="b345-493e-9046-8f93" name="Helcult" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Helbrutes" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="f4fa-10b7-0e31-0ca7" name="Chaos Cultists" defaultEntryId="7490-ed47-694e-f86e" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="7490-ed47-694e-f86e" targetId="b9a9-557f-f8fb-4377" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="f605-1a30-0ba8-fe26" name="Helbrute" defaultEntryId="4c0f-5e1d-d4a7-d34f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4c0f-5e1d-d4a7-d34f" targetId="c3c4-425d-e94e-1b26" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="3a36-20e8-fb38-6864" name="Apocalyptic Fury" hidden="false" page="0">
+          <description>The Helbrute has Rage. When rolling to hit with the Helbrute&apos;s Melee attacks, any unmodified rolls of a 1 hit a friendly model instead. Randomly determine (for each roll of a 1) which models within 6&quot; of the Helbrute are hit instead.</description>
+          <modifiers/>
+        </rule>
+        <rule id="db3f-ddcb-2d0a-ab55" name="Living Idol of Chaos" hidden="false" page="0">
+          <description>As long as the Helbrute is alive, the Cultists have Fearless. If the Helbrute is destroyed, the cultists lose Fearless and gain Zealot.</description>
+          <modifiers/>
+        </rule>
+        <rule id="420a-ae67-2996-96d9" name="Human Shields" hidden="false" page="0">
+          <description>If the Helbrute is partially obscured from one or more of the formations cultists, it recieves a 3+ Cover save but a model from the cultist unit is removed (without saves) for each successful save as a result of this rule.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
     <entry id="0d77-1f37-3b32-c978" name="Heldrake" points="170.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
@@ -18543,6 +18037,67 @@ The nominated unit has Fearless and +1 Strength for the entire game.</descriptio
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="8deb-3f12-acc9-fd78" name="Heldrake Fear Squadron" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="5c9c-86c0-453e-e666" name="Heldrakes" defaultEntryId="5098-3d4e-7523-bd90" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="5098-3d4e-7523-bd90" targetId="0d77-1f37-3b32-c978" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="34f7-5856-2730-dac6" name="Fuelled by Fear" hidden="false">
+          <description>Removes the Once per Game restriction on Daemonforge. All other restrictions still apply.</description>
+          <modifiers/>
+        </rule>
+        <rule id="bbe0-5271-f392-ca40" name="Harbingers of the Apocalypse" hidden="false">
+          <description>The squadron is deployed with the rest of the army. After deployment but before first turn, the Heldrake may move 60&quot; in which they may make an out of sequence Vector Strike (does not cause Morale checks).
+If the special Vector Strike is used, the squadron may not make another that turn, but may fire its other weapons as normal.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="ad0c-fa4b-a960-a007" name="Helfist Murderpack" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Helbrutes" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="bb82-3c72-9efd-272c" name="Helbrutes" defaultEntryId="3561-8d15-7b43-5fbf" minSelections="5" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="3561-8d15-7b43-5fbf" targetId="c3c4-425d-e94e-1b26" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="bc6c-fb0c-6974-9ad8" name="Murderpack" hidden="false" page="0">
+          <description>All Helbrutes in this formation count as a single Vehicle Squadron</description>
+          <modifiers/>
+        </rule>
+        <rule id="82da-bdff-8ab0-7fb2" name="Pack Leader" hidden="false" page="0">
+          <description>The Helbrute Champion has the Vehicle (Character) unit type and the Aura of Dark Glory. If the Helbrute champion is still alive, the controlling player may chose what the crazed result for ALL Helbrutes in the formation instead of rolling (the crazed result is the same for all the Helbrutes).</description>
+          <modifiers/>
+        </rule>
+        <rule id="a44b-ee2b-24b4-f288" name="Death of a Leader" hidden="false" page="0">
+          <description>IF the Helbruite Champion is destroyed, all other Helbrutes gain Rage.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="a11b-ffca-8c56-de0e" name="Huron Blackheart" points="160.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
@@ -18850,6 +18405,54 @@ At the beginning of each turn, roll a D3 (consulting the table in Hurons profile
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="3112-8055-b691-9851" name="Kharn&apos;s Butcherhorde" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4345-cad3-50fb-b148" name="Chaos Space Marines" defaultEntryId="71ec-88b7-227a-00df" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="71ec-88b7-227a-00df" targetId="3354-24e9-4ec9-506b" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="2c2f-67c4-e202-4a71" name="Khorne Berzerkers" defaultEntryId="a88b-6e72-bbf8-c3ce" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a88b-6e72-bbf8-c3ce" targetId="d990-6016-2e27-d72f" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="c7c8-c02f-9706-511a" name="Kharn the Betrayer" defaultEntryId="7713-0b9b-f464-f577" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="7713-0b9b-f464-f577" targetId="08ed-5bd1-f1e7-6419" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="d069-69c8-0061-4af1" name="Blood and Rage" hidden="false">
+          <description>When a unit in this formation rolls an 8 for charge range (including re-rolls), then all models in that unit double their attack stat for that turn.</description>
+          <modifiers/>
+        </rule>
+        <rule id="79df-3fd9-61d3-b905" name="Slaughter without Respite" hidden="false">
+          <description>Each time a model in the formation scores a 6 on a to-hit roll, then it gains an extra attack. If additional 6&apos;s are rolled, then these also gain extra attacks.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="d990-6016-2e27-d72f" name="Khorne Berzerkers" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
@@ -19859,6 +19462,43 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
         </link>
       </links>
     </entry>
+    <entry id="6095-6691-ebad-602a" name="Maelstrom of Gore" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="685c-d63a-648d-9fbb" name="Chaos Lord or Kharn" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="7108-fd49-5b64-2917" targetId="08ed-5bd1-f1e7-6419" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="c136-9743-b5cb-f422" targetId="598f-3cba-b8c5-e748" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="ff09-e509-0adf-6960" name="Berzerkers" defaultEntryId="a174-65b4-01d1-f164" minSelections="8" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a174-65b4-01d1-f164" targetId="d990-6016-2e27-d72f" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="a991-96fa-4b37-664b" name="Slick with Ensorcelled Blood" hidden="false">
+          <description>If any unit in this formation is withing 18&quot; of the Lord/Kharn, then that unit gets Fleet and Move through Cover. They also add 3&quot; to their charge move.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
     <entry id="d71dd962-cb90-0dd4-e165-462ae8e62e52" name="Mark of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
       <entryGroups/>
@@ -19993,6 +19633,38 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
           <modifiers/>
         </link>
         <link id="954d-b1a7-ff52-999d" targetId="36dff9dc-045d-ed08-e3c6-91e398814208" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2160-a7de-6d37-4310" name="Mayhem Pack" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Helbrutes" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="5fed-5f92-387a-5596" name="Helbrute" defaultEntryId="2625-162b-e101-5264" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="2625-162b-e101-5264" targetId="c3c4-425d-e94e-1b26" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="dd30-5462-5ffe-bb32" name="Mayhem from the Maelstrom" hidden="false" page="0">
+          <description>All of the Units in the formation must start in Reserve. When rolling Reserve rolls, roll a single D6 for the entire unit. On a successful Reserve roll, the entire formation arrives via Deep Strike</description>
+          <modifiers/>
+        </rule>
+        <rule id="06a8-478a-f91d-b8ff" name="Tormented Terrors" hidden="false" page="0">
+          <description>At the start of each of your Movement phase, make a single Crazed result roll regardless if the Helbrutes have suffered a Glance or Penetrating hit.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="f129-4bd9-2c67-fbb8" targetId="893e92c2-a4b4-6646-8bac-bfa4ad7a776d" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -20180,7 +19852,7 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
             </entry>
           </entries>
           <entryGroups>
-            <entryGroup id="574d-c8eb-4fd0-f611" name="Bolt Pistol Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="574d-c8eb-4fd0-f611" name="Bolt Pistol Arm" defaultEntryId="f110-fcb0-2aaf-090c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="f110-fcb0-2aaf-090c" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -20283,7 +19955,7 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
               <modifiers/>
               <links/>
             </entryGroup>
-            <entryGroup id="d84d-f179-bc14-92c7" name="CCW Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="d84d-f179-bc14-92c7" name="CCW Arm" defaultEntryId="2701-c06f-db86-a5fd" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="2701-c06f-db86-a5fd" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -20997,7 +20669,7 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
             </entry>
           </entries>
           <entryGroups>
-            <entryGroup id="6ca1-0dd8-3244-187b" name="Melee Weapon" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="6ca1-0dd8-3244-187b" name="Melee Weapon" defaultEntryId="7d35-ef6c-edb3-a2e5" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="7d35-ef6c-edb3-a2e5" name="Plague Knife" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -21076,7 +20748,7 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
               <modifiers/>
               <links/>
             </entryGroup>
-            <entryGroup id="3799-f9d9-584c-543a" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="3799-f9d9-584c-543a" name="Ranged Weapon" defaultEntryId="eff8-7c51-c100-fd14" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="25ae-4b29-e68d-e371" name="Combi-bolter" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -21920,7 +21592,7 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
             </entry>
           </entries>
           <entryGroups>
-            <entryGroup id="3a0f-312a-7cb4-68f4" name="Bolt Pistol Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="3a0f-312a-7cb4-68f4" name="Bolt Pistol Arm" defaultEntryId="fcd3-51aa-a50c-219c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="fcd3-51aa-a50c-219c" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -22023,7 +21695,7 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
               <modifiers/>
               <links/>
             </entryGroup>
-            <entryGroup id="38ef-2474-a51e-4d37" name="CCW Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="38ef-2474-a51e-4d37" name="CCW Arm" defaultEntryId="bf89-8b87-823a-b2da" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="bf89-8b87-823a-b2da" name="Close Combat Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -22642,6 +22314,29 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
           <modifiers/>
           <links/>
         </entryGroup>
+        <entryGroup id="4558-04c2-4b62-aa66" name="CCW Arm" defaultEntryId="652a-aca7-fe64-b7a8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="e7d4-a542-99ca-3747" targetId="cab4-ac81-3d8d-27a2" linkType="entry group">
+              <modifiers/>
+            </link>
+            <link id="652a-aca7-fe64-b7a8" targetId="510d2050-e668-b844-1ab4-221cd947e968" linkType="entry group">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="63b6-49fd-6568-d688" name="Ranged Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="8bd4-370d-0469-67bb" targetId="0c03faa1-c49d-b0f7-2e58-d86fce11656c" linkType="entry group">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
@@ -22688,9 +22383,29 @@ Super-heavy vehicle, but it may not make Stomp attacks.</description>
           <modifiers/>
         </link>
         <link id="023e-0fe2-8782-31c6" targetId="cab4-ac81-3d8d-27a2" linkType="entry group">
-          <modifiers/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="9832-6438-ea96-d6d6" childId="4cd1-256b-4522-9f23" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
         <link id="30fc-894b-8766-2251" targetId="0231-5019-1144-592d" linkType="entry group">
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="9832-6438-ea96-d6d6" childId="c546-0270-af98-1eaa" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="c2d1-5582-9609-fb49" targetId="59323c0b-e16f-e72a-273d-ca3bb30d53b7" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="1590-633a-d75f-0d26" targetId="530bb69e-c246-fccd-1688-f1cfba50c251" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -22776,6 +22491,77 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="c086-3c8d-92f5-5490" name="The Chosen of Abaddon" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="f7bf-6bfb-4425-5774" name="Chaos Lord or Sorceror" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="98f6-25ce-5b61-9475" targetId="598f-3cba-b8c5-e748" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7a83-a81f-b1eb-ff24" targetId="9832-6438-ea96-d6d6" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="380f-35b3-09c6-c657" name="Chosen or Terminators" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="e922-3b77-646f-ed2c" name="Chosen" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="ec11-5ec1-035f-73d2" targetId="d553-752e-86d1-19fd" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="94e2-0fb9-6a2a-a88b" name="Terminators" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b9da-935c-8cca-50d9" targetId="8a3b-80c7-0cf3-e044" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="increment" field="minSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="c086-3c8d-92f5-5490" incrementChildId="f7bf-6bfb-4425-5774" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="c086-3c8d-92f5-5490" incrementChildId="f7bf-6bfb-4425-5774" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="be06-6bd2-ffbb-9a68" name="Blessed by the Chaos Gods" hidden="false">
+          <description>Each Lord or sorceror starts the battle with 1 chaos boon. Roll separately for each character.</description>
+          <modifiers/>
+        </rule>
+        <rule id="1db7-1720-cef0-7994" name="Protect the Despoiler" hidden="false">
+          <description>Any unit in this formation within 12&quot; of Abaddon gets Fearless.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="2cd444f8-1b1c-b8f9-ec16-0667729f56a5" name="The Crucible of Lies" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" page="0">
       <entries/>
@@ -22876,6 +22662,84 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
         </profile>
       </profiles>
       <links/>
+    </entry>
+    <entry id="59dd-b91c-e600-c7c3" name="The Hounds of Huron" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="cef4-04ae-b218-ecc1" name="Chaos Bikers" defaultEntryId="d369-295a-5260-c46a" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="d369-295a-5260-c46a" targetId="101f-b7b9-83a0-d998" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="b39c-90e5-6cdc-125d" name="Lightning strike" hidden="false">
+          <description>The Chaos Lord and all other units in the formation within 12&quot;of him may charge even if they have Turbo-boosted during that turn.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="882f-06e1-db28-3792" targetId="aa22-0c2c-4620-bcab" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="afb3-c45e-3fa8-b3a5" targetId="7bae-917a-2bad-1ca4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f935-acd9-e443-9397" targetId="598f-3cba-b8c5-e748" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="897a-e3ad-ec5c-6c43" name="The Lost and the Damned" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="77dc-9209-1789-5755" name="Dark Apostle" defaultEntryId="a20c-1855-bf53-d75d" minSelections="1" maxSelections="999" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a20c-1855-bf53-d75d" targetId="d630-2b65-3996-c1a3" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="14bd-ddd0-c2d6-2fd5" name="Chaos Cultists" defaultEntryId="05d5-d53d-fe9a-9fc6" minSelections="6" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="05d5-d53d-fe9a-9fc6" targetId="b9a9-557f-f8fb-4377" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="c9e5-e242-1f09-721f" name="Limitless in Number - Boundless in Spite" hidden="false">
+          <description>A single Chaos Cultist unit from the formation may be returned to play after each scheduled break without spending a Strategic Victory Point. This does not count towards the number of units you </description>
+          <modifiers/>
+        </rule>
+        <rule id="f093-01be-87cd-0e0c" name="Boundless in Spite" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="37fd-c368-57ec-1254" name="Warped by Mutation" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="5eed-5287-cdb2-5a0f" targetId="ea5a4db4-c79e-a76d-51c0-330ee9d4e863" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="f5d93a62-3ff7-d984-c64c-5ea5faaccf21" name="The Murder Sword" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
@@ -23019,137 +22883,6 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
     </entry>
     <entry id="7142-e365-1c12-efd6" name="Thousand Sons" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="1b70-e89f-2c25-7263" name="Aspiring Sorcerer" points="58.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="3f31-c068-6eda-9751" name="Gift of Mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e430-0517-0235-0e68" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="59b7-3da3-428f-fbf4" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="fd0f-7a35-dffe-1c15" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="3dc8-2f0f-6291-7f27" name="Aura of Dark Glory" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="b622-0be1-a209-a01b" targetId="792121b8-8a8e-97ee-72e6-aec2805eb879" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="fda1-d5d3-63a6-64d8" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a015-7ae4-647a-3b2b" targetId="a243616a-65df-2af8-f12c-8657bdee994f" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="7403-14dd-9974-6ad3" targetId="5ac9c484-7f7f-b299-64d9-d9ffddb1f66e" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="b2d1-ea9e-bd87-12f9" name="Force Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="732a-9e8b-5329-5732" targetId="510d2050-e668-b844-1ab4-221cd947e968" linkType="entry group">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="ede9-3287-cdd7-7a28" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Aspiring Sorcerer" hidden="false" page="0">
-              <characteristics>
-                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character), Psyker Level 1"/>
-                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
-                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
-                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
-                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
-                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
-                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
-                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
-                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="ae6c-d36b-8414-0aa8" targetId="2231f009-0a6e-e5f3-9976-c631d3ff7565" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1442-119a-7f45-9f1a" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="6c6c-4853-fe5c-abc2" name="Thousand Son" points="23.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="19" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="278a-1c20-1fba-d5d4" name="Boltgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="0741-b058-4f1a-5069" targetId="8b2113df-55b3-2f62-0601-f729b5851ac0" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="7389-265e-c31c-a569" targetId="5ac9c484-7f7f-b299-64d9-d9ffddb1f66e" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="df0c-355c-1c8c-2344" name="Aura of Dark Glory" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4c56-e123-7c8b-9d9f" targetId="792121b8-8a8e-97ee-72e6-aec2805eb879" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="aacb-203d-a021-62b7" name="Icon of Flame" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
@@ -23163,7 +22896,146 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="06e8-9fd7-291f-ec97" name="Unit Size: 5-20" defaultEntryId="1df5-a312-944c-cc6f" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="1df5-a312-944c-cc6f" name="Thousand Son" points="23.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="19" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries>
+                <entry id="9fbb-b7ea-826a-a08c" name="Boltgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="47cc-dbc9-046d-04e9" targetId="8b2113df-55b3-2f62-0601-f729b5851ac0" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="67dd-d367-3295-5721" targetId="5ac9c484-7f7f-b299-64d9-d9ffddb1f66e" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="5766-e4a2-68bf-b8a5" name="Aura of Dark Glory" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="10f6-176b-d969-aa93" targetId="792121b8-8a8e-97ee-72e6-aec2805eb879" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="36dc-36c9-e44a-4527" name="Aspiring Sorcerer" points="58.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries>
+                <entry id="1e4c-d65f-a364-a178" name="Gift of Mutation" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="75a7-c8a5-1400-ed25" targetId="8dcce35e-5df4-e525-85e5-b4ec37094bbb" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="3a4d-e2fb-e462-dbf6" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="fa57-684a-0b56-867c" targetId="aa59fd97-cd0c-cbc4-9d1e-093438bf6e45" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="7164-8e54-f054-f5d8" name="Aura of Dark Glory" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="f319-f64a-a21d-8ef0" targetId="792121b8-8a8e-97ee-72e6-aec2805eb879" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="74cc-9c02-ba88-a224" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="6fe4-41a0-713d-aae1" targetId="a243616a-65df-2af8-f12c-8657bdee994f" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="fa30-1c9a-a021-4be3" targetId="5ac9c484-7f7f-b299-64d9-d9ffddb1f66e" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="e73c-fe70-3c0d-0c56" name="Force Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="4748-2be5-e6bc-f73e" targetId="510d2050-e668-b844-1ab4-221cd947e968" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="44df-f2d1-ac6d-e411" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Aspiring Sorcerer" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character), Psyker Level 1"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="faca-05a8-e46e-b526" targetId="2231f009-0a6e-e5f3-9976-c631d3ff7565" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="07c6-fde2-37ec-c992" targetId="ae970133-d0be-0936-0b4b-009985e0be18" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles>
@@ -23200,6 +23072,226 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="ec73-e5c1-9eb9-e128" name="Thousand Sons War Coven" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
+      <entries>
+        <entry id="6bdd-a42c-97ea-4842" name="Psychic Choir: Storm of Change" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="2e4b-1b95-1961-3e1f" name="Lifedrain" hidden="false">
+              <description>Each time the power&apos;s used, remove up to 3 models in the formation from play. The number removed is the value of &quot;X&quot;.</description>
+              <modifiers/>
+            </rule>
+            <rule id="2473-2c63-e6b9-07f4" name="Storm of Change" hidden="false">
+              <description>Psychic Choir: 
+Warp Charge 2
+Witchfire Power.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="c1c5-0cf5-2f17-3b30" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Psychic Choir: Storm of Change" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault X, Blast, Lifedrain, Vortex"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="c716-e71b-7547-17c1" targetId="27ff1af5-9050-3cbe-8eee-df27c79a0917" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="c1fd-4fa8-e4da-3f97" name="Ahriman or Mastery Level 3 Sorcerer" defaultEntryId="96d0-9b6d-c8ac-a643" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="96d0-9b6d-c8ac-a643" targetId="4824-f3b6-ebde-3155" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="a1f1-1e87-bd31-e5e0" targetId="9832-6438-ea96-d6d6" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="5d9e-ef58-dffd-9359" name="Mastery Level 1 Sorcerers" defaultEntryId="d5a8-f60d-b398-440d" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="d5a8-f60d-b398-440d" targetId="9832-6438-ea96-d6d6" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="dfb9-aa36-0b2b-a1f3" name="Tide of Spawn" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse">
+      <entries>
+        <entry id="15b2-9821-6511-c953" name="Chaos Spawn" points="30.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="3345-3172-44f8-d4c4" name="Marks of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="7eec-ba3a-0f8e-6290" name="Mark of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="4dda-d8ae-fb10-1acd" targetId="e53e9738-2619-dece-cdd0-a3b06edcd0a5" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="d91e-127f-22b9-c213" name="Mark of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b2f3-de5e-58e6-0af3" targetId="f7153095-5189-cd0c-d397-3c5c13fd1168" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="c79f-1ecf-b2a6-09fd" name="Mark of Nurgle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="6.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1472-1c58-2c8f-9efe" targetId="2d3dd5aa-ee83-304c-3129-f7ecb73f1928" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="a2ae-111a-68b1-b2d6" name="Mark of Slaanesh" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="dfb9-aa36-0b2b-a1f3" incrementChildId="15b2-9821-6511-c953" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="79e7-f099-c86c-b640" targetId="69dc1813-9e46-c062-cf10-b83e3eff3bad" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="67ad-0112-b73d-333c" name="The Final Blessing of the Gods." hidden="false">
+          <description>The unit is not deployed normally. From turn 2 onwards, choose one friendly un-engaged infantry unit at least 1&quot; away from an enemy model and has the same number of models as this formation. All models in the unit become the spawns in this formation with full wounds and no upgrades (except the mark they already had).
+
+The unit must immediately disembark their transport before turning into the spawn.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="cf8d-e138-0d3e-8b0e" targetId="5d03f0dc-b84b-6878-b36c-2cf4140a053d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="80c3-d333-f5ab-a592" targetId="a29b139e-6d67-8464-7266-814ce16c1205" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="7cdb-4d39-b744-973a" targetId="4bf37f51-e484-ff05-0545-f477a09d1f6b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="fdae-6668-5629-4075" targetId="2a4fd5b9-69cf-5ecf-8225-e07f016c2a52" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1892-54fe-0920-fee6" targetId="b3feb676-c1d4-3d48-a8b7-3aa4a87188ef" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="71fe-c6b9-6b56-8601" targetId="c36b4aae-d2ae-5058-2d3e-80d114a6043a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4e93-e687-b7a4-5c69" targetId="aa1504f8-0ab7-d06c-cb7d-8eef3c2911cd" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="ab61-76b2-4ab0-b7c9" name="Trinity of Blood" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse: Pandorax">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="6a8b-0c9f-e3fe-1ef5" name="Khorne Lord of Skulls" defaultEntryId="e63d-3272-b550-9503" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="e63d-3272-b550-9503" targetId="0ef1-079d-c3b9-4bd0" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="ac13-5f3f-8a3a-f1e4" name="Cloud of Fury" hidden="false">
+          <description>At the beginning of the Assault phase, all non-vehicle units within 12&quot; of this formation gain Rage</description>
+          <modifiers/>
+        </rule>
+        <rule id="4ffb-e8c7-27ab-7363" name="Wounds in the World" hidden="false">
+          <description>Once per game: At the beginning of your opponents movement phase, declare to use this ability.
+
+All enemy models within 24&quot; of the formation must take a dangerous terrain test during their movement that phase. 
+
+Flying units ( including Flying Monstrous Creatures, Flying Gargantuan Creatures and Super Heavy Fliers), Skimmers, Jump Infanty, Jet Pack Infantry and Jetbikes are not affected by this ability.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="178b-a991-19ba-d4e2" name="Typhus" points="230.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
@@ -23618,7 +23710,7 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="fac0-aa14-09f2-54ff" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="fac0-aa14-09f2-54ff" name="Ranged Weapon" defaultEntryId="691f-4b87-fcfa-e9df" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="691f-4b87-fcfa-e9df" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -23697,7 +23789,7 @@ At the end of a phase that the Black Mace caused an unsaved wound, all non vehic
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="98f7-505a-1bfd-82d7" name="Close Combat Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="98f7-505a-1bfd-82d7" name="Close Combat Weapon" defaultEntryId="da13-641a-bb82-4082" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="da13-641a-bb82-4082" name="Power Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -24183,7 +24275,7 @@ Curse: Roll to hit as per normal againt one enemy vehicle within 18&quot;. If su
       <modifiers/>
       <links/>
     </entryGroup>
-    <entryGroup id="510d2050-e668-b844-1ab4-221cd947e968" name="Force Weapon options" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entryGroup id="510d2050-e668-b844-1ab4-221cd947e968" name="Force Weapon options" defaultEntryId="7ba31de6-2773-1aa7-86a4-b5b58add5702" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="d5d44c4c-aac2-0458-f6b3-cfd44a762564" name="Force Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -26528,6 +26620,21 @@ Codex: Grey Knights
     <profile id="39727fe9-2186-da1f-121a-ba156ae612eb" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Warpflame Gargoyles" hidden="false">
       <characteristics>
         <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="All weapons on the Vehicle have Soul Blaze"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="9dd4-1962-1bdb-f55a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Havoc" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
Dark Apostle: added grenades, default weapons
Daemon Prince: Removed duplicate warlord, default CCW,
Chaos Lord: added grenades, hid term weapons by default
Sorcerer: corrected gear, added grenades, hid term weapons by default
Terminators: Default weapons
Helbrute: Default weapons
Infantry champions (all): Default Weapons
