### PR TITLE
Allow fewer than 4 Pathfinders with Carbines when using Special Weapons.

### DIFF
--- a/Tau - Codex (2015).cat
+++ b/Tau - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24a0-49b6-ecef-1c5a" revision="6" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="23" battleScribeVersion="1.15" name="Tau Empire: Codex (2015)" authorName="Eric Falsken" authorContact="eric@everylittlething.net" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24a0-49b6-ecef-1c5a" revision="7" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="23" battleScribeVersion="1.15" name="Tau Empire: Codex (2015)" authorName="Eric Falsken" authorContact="eric@everylittlething.net" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="fb367433-58d4-8e73-798d-a739f074020a" name="Air Superiority Wing" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Apocalypse" page="177">
       <entries/>
@@ -6907,7 +6907,7 @@ Killing Blade: Rending until the end of the current phase.</description>
               </profiles>
               <links/>
             </entry>
-            <entry id="039e387a-cd36-ab28-e29f-b1ef15c25e79" name="Pathfinder" points="11.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="039e387a-cd36-ab28-e29f-b1ef15c25e79" name="Pathfinder" points="11.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="623af835-35e1-6ad8-ecb1-d6dd7207e16a" name="Pulse Carbine with Markerlight" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
                   <entries/>


### PR DESCRIPTION
Fixes #1559
