### PR TITLE
Wolf Guard Pack Leader in Scouts fix.

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -29526,20 +29526,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
     <entryGroup id="8842-c9df-7ec4-540b" name="Pack Leader ws" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="af37-5bc8-1ff2-dbce" name="Wolf Guard Pack Leader" points="24.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="dc91-f68d-895f-e7c4" name="Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="7b6c-0f68-66fb-25b0" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -29548,7 +29535,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             <link id="a6ce-cd93-4d80-2fff" targetId="6cde4ea9-dec0-1f7f-d01d-c3e14ffd1f27" linkType="profile">
               <modifiers/>
             </link>
-            <link id="1526-0f7d-e4e3-5185" targetId="e09c610a-0d70-2b6b-02f1-6e121086500c" linkType="entry group">
+            <link id="1526-0f7d-e4e3-5185" targetId="1c95-b864-03d6-1ca2" linkType="entry group">
               <modifiers/>
             </link>
             <link id="3958-43f1-8683-ccac" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
@@ -34687,6 +34674,389 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </link>
       </links>
+    </entryGroup>
+    <entryGroup id="1c95-b864-03d6-1ca2" name="WG Pack Leader Scout Weapons" minSelections="1" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4385-8717-0fcb-b015" name="Weapon 1" defaultEntryId="cbed-1c0d-268d-c83c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="cbed-1c0d-268d-c83c" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="fc2c-33ef-a175-58fa" targetId="82de7a82-9e87-8dc1-6d88-fbe1ee0c024c" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="fc1f-127b-df19-83cf" name="Combi Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="f93d-1abc-866e-5081" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="21dc-e63f-e38f-3015" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="f7b2-1f7c-3517-0e23" targetId="06d73e79-f635-f39c-d438-9ac3c7929b21" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="53cd-a34a-b913-bad6" name="Combi Melta" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="2487-586e-ab8e-0b30" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="0ea3-a402-9ebf-118d" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="f027-1aef-4a06-1c60" targetId="87a24fa9-2897-5df2-8bd7-dbd7f6ee9ead" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="f39d-d54c-51b2-c8a1" name="Combi Plasma" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b7e5-b577-9212-e71d" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="b958-bb1f-1cd7-6b5a" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="f781-9fe4-948a-3f58" targetId="06d67607-bdf1-ff59-f570-9935f592255e" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="fce7-188e-a74c-03f3" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="4ec3-189e-9c05-49ee" targetId="5e3d402f-87bd-b6a1-e5b0-20c3fc1df6c2" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="9f70-df4f-bc5c-2e7f" name="Storm Bolter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="499b-ba3e-ae18-f6e1" targetId="a2da2b98-1a14-9a16-f860-077c1544545d" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="e2d5-b427-d87b-f489" name="Frost Axe" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="8363-92c1-d1c8-c601" targetId="8a52ed78-8139-b06a-2f9e-c574962705b6" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="862d-e6ca-9ec0-c289" name="Power Sword" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="702b-aa6f-a5e9-cfba" targetId="8ac9b561-512c-7d0d-8dcc-aa07e0bde4b9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="b902-3512-7abf-03b6" name="Storm Shield" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="d126-b607-b651-bb24" targetId="4d818034-4bf4-6fbf-b1ea-408b69ef1843" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="daac-12a1-9ac8-53be" name="Thunder Hammer" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="9ba6-e4d0-2b1b-a188" targetId="85d2dada-b527-d574-f923-56ea9f013e6d" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="a135-774e-1ee7-c16b" name="Wolf Claw" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="1c95-b864-03d6-1ca2" incrementChildId="a135-774e-1ee7-c16b" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="1c95-b864-03d6-1ca2" childId="be57-9311-5faa-e7e1" field="selections" type="at least" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="e440-58a2-e168-df06" targetId="3d5883da-d159-4a14-2e67-9bcb4b8e365a" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7196-67ed-d131-5046" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="3201-db0e-b950-76fc" targetId="d79fcca2-19d9-3218-96f2-78edca3fe208" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="6949-865b-fc37-c2b7" name="Frost Sword" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="77cd-d028-e8f0-025e" targetId="d67e53dc-70e3-ddef-bb9a-35f623ad99a7" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="d774-f6d7-fca1-b940" name="Weapon 2" defaultEntryId="beef-b195-a81e-cbef" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="d458-3cae-70d6-1533" name="Combi Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="aa32-d20d-fb5c-5ebb" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="2349-f27e-6228-a7c1" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="a2af-2c6e-d5d4-2cd3" targetId="06d73e79-f635-f39c-d438-9ac3c7929b21" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="5c7a-9ba1-834d-5747" name="Combi Melta" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="f92e-74a8-9a1c-cf11" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="b86d-6958-03fa-412e" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="7828-8c58-2511-ce30" targetId="87a24fa9-2897-5df2-8bd7-dbd7f6ee9ead" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="9358-a1f0-5dd9-d319" name="Combi Plasma" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="fc0f-875b-60cb-78a6" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="1271-254e-3349-294f" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="b37b-6f4d-59e7-7081" targetId="06d67607-bdf1-ff59-f570-9935f592255e" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="a156-4576-f9cf-7c48" name="Frost Axe" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="71b4-c20c-e28a-620b" targetId="8a52ed78-8139-b06a-2f9e-c574962705b6" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="77b1-fd80-8246-ad6f" name="Frost Sword" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="e3ea-a370-c222-a9da" targetId="d67e53dc-70e3-ddef-bb9a-35f623ad99a7" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7984-a6b6-fcee-3a5e" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="7f9c-e372-813f-1c39" targetId="5e3d402f-87bd-b6a1-e5b0-20c3fc1df6c2" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="eeb4-c8d9-ebca-bd1e" name="Power Fist" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="8ee2-0b77-b912-b312" targetId="d79fcca2-19d9-3218-96f2-78edca3fe208" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="c0ba-87c0-9216-a737" name="Power Sword" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="d5a9-9e8b-6e60-a2c5" targetId="8ac9b561-512c-7d0d-8dcc-aa07e0bde4b9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="279c-7dd6-d3a9-1493" name="Storm Bolter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="e928-99a7-680b-3994" targetId="a2da2b98-1a14-9a16-f860-077c1544545d" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="f193-8826-238a-6a92" name="Storm Shield" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="78fa-0a64-a170-f88f" targetId="4d818034-4bf4-6fbf-b1ea-408b69ef1843" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="daf6-25f1-151d-f6b8" name="Thunder Hammer" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="77b3-43a6-f133-8828" targetId="85d2dada-b527-d574-f923-56ea9f013e6d" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="be57-9311-5faa-e7e1" name="Wolf Claw" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="1c95-b864-03d6-1ca2" incrementChildId="be57-9311-5faa-e7e1" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="1c95-b864-03d6-1ca2" childId="a135-774e-1ee7-c16b" field="selections" type="at least" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="46f0-d130-bd52-85df" targetId="3d5883da-d159-4a14-2e67-9bcb4b8e365a" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="beef-b195-a81e-cbef" name="Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="f1ba-2c5e-3141-3343" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <links/>
     </entryGroup>
   </sharedEntryGroups>
   <sharedRules>


### PR DESCRIPTION
Wolf Guard Pack Leader in Scouts can now replace both the Bolt Pistol and Bolter.

Will Fix #1707 if it needs to be.
