### PR TITLE
Fix Points in Bonus Options for Tech Priest

### DIFF
--- a/Skitarii - Codex.cat
+++ b/Skitarii - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2301-1cab-6d58-f23b" revision="20" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="17" battleScribeVersion="1.15" name="Skitarii: Codex (2015)" books="Codex: Skitarii" authorName="Axis of Entropy" authorContact="axisofentropy@gmail.com" authorUrl="https://github.com/BSData/wh40k/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2301-1cab-6d58-f23b" revision="21" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="17" battleScribeVersion="1.15" name="Skitarii: Codex (2015)" books="Codex: Skitarii" authorName="Axis of Entropy" authorContact="axisofentropy@gmail.com" authorUrl="https://github.com/BSData/wh40k/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="0a94-b6ee-6c90-cdc0" name="Battle Maniple (War Conv.)" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Codex: Skitarii" page="64">
       <entries>
@@ -3534,7 +3534,7 @@ Third and last, enjoy the formation!</description>
             </link>
           </links>
         </entry>
-        <entry id="fc90-1f7a-9072-bd2c" name="Mask of the Alpha Dominus" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entry id="fc90-1f7a-9072-bd2c" name="Mask of the Alpha Dominus" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>


### PR DESCRIPTION
Changed Points cost for Mask of the Alpha Dominus from 0 to 15
