### PR TITLE
Dark Eldar v19

### DIFF
--- a/Dark_Eldar_Codex_(2014).cat
+++ b/Dark_Eldar_Codex_(2014).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="635e04e0-204e-2672-055e-6d081ee0fc93" revision="16" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Dark Eldar: Codex (2014)" books="" authorName="BSData on GitHub" authorContact="@BSData" authorUrl="https://github.com/BSData/wh40k#warhammer-40000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="635e04e0-204e-2672-055e-6d081ee0fc93" revision="18" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Dark Eldar: Codex (2014)" books="" authorName="BSData on GitHub" authorContact="@BSData" authorUrl="https://github.com/BSData/wh40k#warhammer-40000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="eb21d12e-1d75-d23b-d086-af82f107b768" name="Court of the Archon" points="0.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="0" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
@@ -19,7 +19,7 @@
               <modifiers>
                 <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="force type" childId="4b8a8c53-5663-00d3-604d-20800b31a3b0" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="force type" childId="6de4-bc91-9a7b-4eb9" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -163,7 +163,7 @@
       <modifiers>
         <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="force type" childId="a06f3ca3-acc0-53b1-b23c-1c2a2db22cb9" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="force type" childId="6de4-bc91-9a7b-4eb9" field="selections" type="equal to" value="1.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -196,41 +196,8 @@
         </link>
       </links>
     </entry>
-    <entry id="2bd74183-85bd-7f28-f628-2ae8791f90c5" name="Show FW models" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="4b8a8c53-5663-00d3-604d-20800b31a3b0" name="1. HQ" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="9c7817ce-b463-c89b-907e-1e7ebe7bec62" name="2. Elites" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="d5ff853a-d669-af6b-7c1a-244db719cb45" name="3. Fast Attack" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="a06f3ca3-acc0-53b1-b23c-1c2a2db22cb9" name="4. Heavy Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
+    <entry id="6de4-bc91-9a7b-4eb9" name="Show Forgeworld" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
       <entryGroups/>
       <modifiers/>
       <rules/>
@@ -319,7 +286,7 @@
       <modifiers>
         <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="force type" childId="a06f3ca3-acc0-53b1-b23c-1c2a2db22cb9" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="force type" childId="6de4-bc91-9a7b-4eb9" field="selections" type="equal to" value="1.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -335,7 +302,7 @@
       <modifiers>
         <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
-            <condition parentId="force type" childId="d5ff853a-d669-af6b-7c1a-244db719cb45" field="selections" type="equal to" value="1.0"/>
+            <condition parentId="force type" childId="6de4-bc91-9a7b-4eb9" field="selections" type="equal to" value="1.0"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -878,7 +845,7 @@
               <modifiers>
                 <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="force type" childId="4b8a8c53-5663-00d3-604d-20800b31a3b0" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="force type" childId="6de4-bc91-9a7b-4eb9" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -2094,9 +2061,9 @@
     <entry id="775786c3-a7e0-95c5-996b-96a0cc7c8408" name="Kabalite Warriors" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
       <entries/>
       <entryGroups>
-        <entryGroup id="0f554f51-72bd-d048-510d-a82c6a370abd" name="5 - 20 Kabalite Warriors" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="0f554f51-72bd-d048-510d-a82c6a370abd" name="5 - 20 Kabalite Warriors" defaultEntryId="47f187f0-a16a-3370-9d1a-e8b3e61a347b" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="47f187f0-a16a-3370-9d1a-e8b3e61a347b" name="Kabalite Warrior" points="8.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="47f187f0-a16a-3370-9d1a-e8b3e61a347b" name="Kabalite Warrior" points="8.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries>
                 <entry id="a24de8d9-4e1a-16fe-4af6-439ae2c22da1" name="Splinter Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
                   <entries/>
@@ -2766,6 +2733,114 @@
           <modifiers/>
         </link>
         <link id="3b7c6bc7-d1ed-3526-3efd-9d201445d768" targetId="1f7568f1-36e6-49dd-ce0d-862134b7151d" linkType="entry group">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="d65b-986c-3381-c061" name="Raven Strike Fighter *" points="205.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA: Aeronautica (2012)" page="69">
+      <entries>
+        <entry id="bf5d-8cee-ecb5-89c8" name="Twin-linked Dark Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="8454-d821-2ebe-608a" targetId="e7ade954-69c9-8bc4-10e6-ba2f4e3938bd" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="b7d9-7234-3780-8535" name="Spliterstorm cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="63c7-f267-e390-8946" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Spliterstorm cannon" hidden="false" book="IA: Aeronautica (2012)" page="69">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="X"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 10, Poisoned (4+)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="c8a6-6bf6-1f87-3f08" name="Options:" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="64a4-9568-8157-cd3b" name="Flickerfield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="85ca-43f3-4dab-4aaf" targetId="68dc2f66-b1b3-3d42-e6b4-cdf631de4f4e" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="ade9-8b23-0b01-d5df" name="Night Shields" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="8453-397a-1ec1-6509" targetId="0e1ad416-95b9-b0e6-d6f9-6051d1a79157" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="9d72-4a80-1699-9dc0" name="Evasive" hidden="false" book="???" page="???">
+          <description>(Editor&apos;s note: Possibly &quot;Agile&quot; but no clue if that&apos;s an actual error or what.)</description>
+          <modifiers/>
+        </rule>
+        <rule id="588a-a1df-5679-3327" name="Sky Assassin" hidden="false" book="IA: Aeronautica (2012)" page="69">
+          <description>When entering play via Deep Strike, if it does so within 12&quot; of an enemy Flyer or Skimmer, its controlling player may re-roll the Scatter dice to determine where it arrives.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="ea1c-d775-fe1b-cb04" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Raven Strike Fighter" hidden="false" book="IA: Aeronautica (2012)" page="69">
+          <characteristics>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="10"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="10"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Flyer"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="eae2-488e-52e5-59b9" targetId="1e968bef-1a90-c7ef-5327-10bc60c6a1b6" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a7ac-e868-de65-f65c" targetId="27fd7d6b-b679-5af5-0201-db2e55e7fe7d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="dda7-1c22-61fb-1c16" targetId="7c3ba9a4-61bc-0325-4734-9d734ecf796c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6d53-ef4a-5e3e-bd5f" targetId="5465-907d-42b9-c1bd" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="54a0-0b47-2ece-fa75" targetId="302a-4621-5e54-1d84" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -3603,7 +3678,32 @@
             </entry>
           </entries>
           <entryGroups/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="0531-06d8-d779-1f80" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="ac66-bf51-d65f-d7c7" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="ac66-bf51-d65f-d7c7" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="0531-06d8-d779-1f80" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <links>
             <link id="378aca89-7969-1570-a448-0d551d91b82a" targetId="d55d275d-f0e3-8d5c-040e-4825503ca30b" linkType="entry">
               <modifiers/>
@@ -3611,15 +3711,12 @@
             <link id="02eae57c-0b01-7ae9-a3da-b987eed2f91a" targetId="062f695b-b117-9d66-5298-e07544fd0165" linkType="entry">
               <modifiers/>
             </link>
-            <link id="82ecf4dd-cc46-e8a3-3fee-ba51a0bb686e" targetId="cc43d6d2-19ca-77e3-e517-24743a1e20e5" linkType="entry group">
-              <modifiers/>
-            </link>
             <link id="e19960b2-2d28-dcc9-224b-ba6a6a98c7c3" targetId="f97248f7-5699-fe18-9692-6a78a3ff2197" linkType="entry">
               <modifiers/>
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="a506b259-4e2c-6bee-7562-d7aace223142" name="Pistol" defaultEntryId="1b3bfd30-cf98-db2c-8185-bf48dd77fa26" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="a506b259-4e2c-6bee-7562-d7aace223142" name="Pistol" defaultEntryId="1b3bfd30-cf98-db2c-8185-bf48dd77fa26" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="1b3bfd30-cf98-db2c-8185-bf48dd77fa26" name="Splinter pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
@@ -3636,17 +3733,29 @@
           </entries>
           <entryGroups/>
           <modifiers>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="82ecf4dd-cc46-e8a3-3fee-ba51a0bb686e" field="selections" type="less than" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
+            <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="f0ea-20f2-e27f-6f5e" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="ac66-bf51-d65f-d7c7" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="82ecf4dd-cc46-e8a3-3fee-ba51a0bb686e" field="selections" type="less than" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
+            <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="f0ea-20f2-e27f-6f5e" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="ac66-bf51-d65f-d7c7" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <links>
@@ -3654,14 +3763,7 @@
               <modifiers/>
             </link>
             <link id="ac6ab061-799d-7ec5-5dd3-923760f8e0af" targetId="f97248f7-5699-fe18-9692-6a78a3ff2197" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="e19960b2-2d28-dcc9-224b-ba6a6a98c7c3" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
             </link>
           </links>
         </entryGroup>
@@ -3705,6 +3807,24 @@
         </link>
         <link id="7b2c507a-0279-86d9-1304-b07d999cf459" targetId="386cf84f-0828-744a-2451-0e369ce5f245" linkType="entry">
           <modifiers/>
+        </link>
+        <link id="ac66-bf51-d65f-d7c7" targetId="cc43d6d2-19ca-77e3-e517-24743a1e20e5" linkType="entry group">
+          <modifiers>
+            <modifier type="decrement" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="9f2b3016-a697-0856-3d0c-0bd874c73efc" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="a506b259-4e2c-6bee-7562-d7aace223142" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="f0ea-20f2-e27f-6f5e" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="ae6fb802-062f-fb53-dce7-d7be879c9c7e" childId="0531-06d8-d779-1f80" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </link>
       </links>
     </entry>
@@ -3972,6 +4092,52 @@
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="0531-06d8-d779-1f80" name="The Djin Blade" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="1113-94c9-c60c-4f6c" name="Sentient Blade" hidden="false">
+          <description>When fighting with the Djin Blade, the wielder gains +2 bonus Attacks. Immediately after resolving all of the attacks made with this weapon, roll a single D6 - on a result of 1, the model using this weapon immediately suffers a single Wound, with no saves of any kind allowed. </description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="a271-3a21-153b-726a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Djin Blade" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Sentient Blade"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="f0ea-20f2-e27f-6f5e" name="The Parasite&apos;s Kiss" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="9f12-9d99-e596-ec5d" name="Soul-leech" hidden="false">
+          <description>Each time the bearer inflicts an unsaved Wound with the Parasite&apos;s Kiss it immediately gains one Wound lost previously in the battle. </description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="48b0-eb48-46c9-b1b8" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Parasite&apos;s Kiss" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="1"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Pistol, Master-crafted, Poisoned (2+), Soul-leech"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
     </entry>
     <entry id="91ada884-f1b2-6fb5-a31c-4d5e0b328977" name="Urien Rakarth" points="140.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
       <entries>
@@ -4697,114 +4863,6 @@
         </link>
       </links>
     </entry>
-    <entry id="d65b-986c-3381-c061" name="Raven Strike Fighter *" points="205.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="IA: Aeronautica (2012)" page="69">
-      <entries>
-        <entry id="bf5d-8cee-ecb5-89c8" name="Twin-linked Dark Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="8454-d821-2ebe-608a" targetId="e7ade954-69c9-8bc4-10e6-ba2f4e3938bd" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b7d9-7234-3780-8535" name="Spliterstorm cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="63c7-f267-e390-8946" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Spliterstorm cannon" hidden="false" book="IA: Aeronautica (2012)" page="69">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="X"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 10, Poisoned (4+)"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="c8a6-6bf6-1f87-3f08" name="Options:" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="64a4-9568-8157-cd3b" name="Flickerfield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="85ca-43f3-4dab-4aaf" targetId="68dc2f66-b1b3-3d42-e6b4-cdf631de4f4e" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="ade9-8b23-0b01-d5df" name="Night Shields" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="8453-397a-1ec1-6509" targetId="0e1ad416-95b9-b0e6-d6f9-6051d1a79157" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="9d72-4a80-1699-9dc0" name="Evasive" hidden="false" book="???" page="???">
-          <description>(Editor&apos;s note: Possibly &quot;Agile&quot; but no clue if that&apos;s an actual error or what.)</description>
-          <modifiers/>
-        </rule>
-        <rule id="588a-a1df-5679-3327" name="Sky Assassin" hidden="false" book="IA: Aeronautica (2012)" page="69">
-          <description>When entering play via Deep Strike, if it does so within 12&quot; of an enemy Flyer or Skimmer, its controlling player may re-roll the Scatter dice to determine where it arrives.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="ea1c-d775-fe1b-cb04" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Raven Strike Fighter" hidden="false" book="IA: Aeronautica (2012)" page="69">
-          <characteristics>
-            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS"/>
-            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="10"/>
-            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="10"/>
-            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
-            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
-            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Flyer"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="eae2-488e-52e5-59b9" targetId="1e968bef-1a90-c7ef-5327-10bc60c6a1b6" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a7ac-e868-de65-f65c" targetId="27fd7d6b-b679-5af5-0201-db2e55e7fe7d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="dda7-1c22-61fb-1c16" targetId="7c3ba9a4-61bc-0325-4734-9d734ecf796c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6d53-ef4a-5e3e-bd5f" targetId="5465-907d-42b9-c1bd" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="54a0-0b47-2ece-fa75" targetId="302a-4621-5e54-1d84" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
   </sharedEntries>
   <sharedEntryGroups>
     <entryGroup id="359216fa-43af-366a-a5dc-b73b1fca678e" name="1- 12 of the Court of the Archon" minSelections="1" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -5063,30 +5121,7 @@
     </entryGroup>
     <entryGroup id="65b2e53b-2f3d-c487-dfee-17deeef4e4a6" name="Artefacts of Cruelty" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
-        <entry id="ac76f26a-634f-3463-bbb1-e4ebc6479ff4" name="The Parasite&apos;s Kiss" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="51bbbfd4-3e5e-7d37-f503-29736a373048" name="Soul-leech" hidden="false">
-              <description>Each time the bearer inflicts an unsaved Wound with the Parasite&apos;s Kiss it immediately gains one Wound lost previously in the battle. </description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles>
-            <profile id="1331e664-db5e-ba2b-4684-85aba15ea2f6" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Parasite&apos;s Kiss" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="1"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Pistol, Master-crafted, Poisoned (2+), Soul-leech"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="1eb9bd54-5cd6-96e1-c7cd-72dd5bfafd90" name="The Armour of Misery" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entry id="1eb9bd54-5cd6-96e1-c7cd-72dd5bfafd90" name="The Armour of Misery" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -5101,7 +5136,7 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="0c3f96b3-e00d-308a-af98-3caf1633a4c8" name="The Animus Vitae" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entry id="0c3f96b3-e00d-308a-af98-3caf1633a4c8" name="The Animus Vitae" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -5116,7 +5151,7 @@
             </link>
           </links>
         </entry>
-        <entry id="3670598e-c00c-5f85-608c-bc8533d62714" name="The Archangel of Pain" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entry id="3670598e-c00c-5f85-608c-bc8533d62714" name="The Archangel of Pain" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -5131,7 +5166,7 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="8234e19b-943d-cea4-5d5f-855bf746ca5f" name="The Helm of Spite" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entry id="8234e19b-943d-cea4-5d5f-855bf746ca5f" name="The Helm of Spite" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -5146,33 +5181,17 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="9ec9feae-b2d9-f56d-a61d-79aab6164053" name="The Djin Blade" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules>
-            <rule id="b38548c1-a640-98cd-da45-6ad8ec7e5992" name="Sentient Blade" hidden="false">
-              <description>When fighting with the Djin Blade, the wielder gains +2 bonus Attacks. Immediately after resolving all of the attacks made with this weapon, roll a single D6 - on a result of 1, the model using this weapon immediately suffers a single Wound, with no saves of any kind allowed. </description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles>
-            <profile id="2f7b624d-3924-95d4-66f0-04d84024e975" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Djin Blade" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Sentient Blade"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
       </entries>
       <entryGroups/>
       <modifiers/>
-      <links/>
+      <links>
+        <link id="cce7-1907-5acc-01d6" targetId="f0ea-20f2-e27f-6f5e" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="d806-4b54-b50e-0a47" targetId="0531-06d8-d779-1f80" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
     </entryGroup>
     <entryGroup id="150e3747-3ce0-4200-d155-6f03c5f5a8a9" name="Dedicated Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
@@ -5575,6 +5594,9 @@ which the Night Fighting rules are in effect, all Troops units from this Formati
       <description>+1 cover save</description>
       <modifiers/>
     </rule>
+    <rule id="302a-4621-5e54-1d84" name="Strafing Run" hidden="false" book="BRB 2014" page="172">
+      <modifiers/>
+    </rule>
     <rule id="7c3ba9a4-61bc-0325-4734-9d734ecf796c" name="Supersonic" hidden="false" book="BRB 2014" page="172">
       <description>When moving Flat Out, must move between 18&quot; and 36&quot;.</description>
       <modifiers/>
@@ -5585,6 +5607,9 @@ which the Night Fighting rules are in effect, all Troops units from this Formati
     </rule>
     <rule id="e2474521-9c0b-6902-508c-f809945d7a4a" name="Twin-Linked" hidden="false" book="BRB 2014" page="174">
       <description>Re-rolls all failed To Hit rolls.</description>
+      <modifiers/>
+    </rule>
+    <rule id="5465-907d-42b9-c1bd" name="Vector Dancer" hidden="false" book="BRB 2014" page="174">
       <modifiers/>
     </rule>
     <rule id="1e4062e8-833e-90e6-e087-d68357d73cd7" name="Warlord Trait: Ancient Evil" hidden="false">
@@ -5609,12 +5634,6 @@ which the Night Fighting rules are in effect, all Troops units from this Formati
     </rule>
     <rule id="35e69364-cf41-1e95-ed7b-08956457f582" name="Warlord Trait: Towering Arrogance" hidden="false">
       <description>The Warlord, and all friendly units with the Dark Eldar Faction within 12&quot; of the Warlord, have the Fearless special rule.</description>
-      <modifiers/>
-    </rule>
-    <rule id="5465-907d-42b9-c1bd" name="Vector Dancer" hidden="false" book="BRB 2014" page="174">
-      <modifiers/>
-    </rule>
-    <rule id="302a-4621-5e54-1d84" name="Strafing Run" hidden="false" book="BRB 2014" page="172">
       <modifiers/>
     </rule>
   </sharedRules>

--- a/Dark_Eldar_Codex_(2014).cat
+++ b/Dark_Eldar_Codex_(2014).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="635e04e0-204e-2672-055e-6d081ee0fc93" revision="18" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Dark Eldar: Codex (2014)" books="" authorName="BSData on GitHub" authorContact="@BSData" authorUrl="https://github.com/BSData/wh40k#warhammer-40000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="635e04e0-204e-2672-055e-6d081ee0fc93" revision="19" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Dark Eldar: Codex (2014)" books="" authorName="BSData on GitHub" authorContact="@BSData" authorUrl="https://github.com/BSData/wh40k#warhammer-40000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="eb21d12e-1d75-d23b-d086-af82f107b768" name="Court of the Archon" points="0.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="0" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
@@ -2063,7 +2063,7 @@
       <entryGroups>
         <entryGroup id="0f554f51-72bd-d048-510d-a82c6a370abd" name="5 - 20 Kabalite Warriors" defaultEntryId="47f187f0-a16a-3370-9d1a-e8b3e61a347b" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="47f187f0-a16a-3370-9d1a-e8b3e61a347b" name="Kabalite Warrior" points="8.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="47f187f0-a16a-3370-9d1a-e8b3e61a347b" name="Kabalite Warrior" points="8.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries>
                 <entry id="a24de8d9-4e1a-16fe-4af6-439ae2c22da1" name="Splinter Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
                   <entries/>


### PR DESCRIPTION
Corrected Minimum initial Squad Size requirement from 3 to 5. Closed
#1861

Updated from v18 after cancelling initial pull request on #1860

Updated Succubus to allow taking Archite Glaive and CC Weapon or Pistol
and CC weapon to match official errata. Closed #1677

Removed Multiple selection for ForgeWorld and replaced with single
‘Show Forgeworld’. Closed #1816

Resolved issue with being unable to take Archite Glaive and CC weapon.
Closed #1848

Resolved issue allowing model to take Djin Blade (Artefact of Cruelty)
in addition to other Melee Weapon (i.e. CC Weapon/Agonizer/Power
Sword). Closed #1853
