### PR TITLE
Update to Add Questoris Knight Porphyrion

### DIFF
--- a/Imperial Knights - Codex (2015).cat
+++ b/Imperial Knights - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6940-50fe-5175-21fa" revision="19" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Imperial Knights: Codex (2015)" books="Imperial Knights: Codex (2015)" authorName="Senpai514" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6940-50fe-5175-21fa" revision="20" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Imperial Knights: Codex (2015)" books="Imperial Knights: Codex (2015)" authorName="Senpai514" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="0141e356-7ddf-bc5f-1e1d-e301bdabded2" name="Adamantine Lance" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
@@ -989,6 +989,9 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             <link id="5073-23d9-3820-67a7" targetId="21f2-5614-1166-84d9" linkType="entry">
               <modifiers/>
             </link>
+            <link id="79cd-bf56-a85d-62a7" targetId="6a37-7a24-962b-5d8c" linkType="entry">
+              <modifiers/>
+            </link>
           </links>
         </entryGroup>
       </entryGroups>
@@ -1635,7 +1638,7 @@ Catastrophic Damage table.</description>
       <entryGroups>
         <entryGroup id="b519-bb78-0873-6c02" name="5 Imperial Knights (of any type)" minSelections="5" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="bb41-6f53-3017-a101" name="Questoris Knight Magaera" points="395.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
+            <entry id="bb41-6f53-3017-a101" name="Questoris Knight Magaera" points="395.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
               <entries>
                 <entry id="fb24-7725-1aad-cd88" name="Phased Plasma-fusil" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -2336,7 +2339,7 @@ Catastrophic Damage table.</description>
                 </link>
               </links>
             </entry>
-            <entry id="4608-be02-dda4-fa49" name="Cerastus Knight-Lancer" points="400.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="lancer.pdf" page="0">
+            <entry id="4608-be02-dda4-fa49" name="Cerastus Knight-Lancer" points="400.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="lancer.pdf" page="0">
               <entries>
                 <entry id="8376-0f29-cae3-0dc8" name="Cerastus Shock Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
@@ -2452,7 +2455,7 @@ Catastrophic Damage table.</description>
                 </link>
               </links>
             </entry>
-            <entry id="b4b8-9e5b-060f-38e4" name="Cerastus Knight-Castigator" points="380.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="b4b8-9e5b-060f-38e4" name="Cerastus Knight-Castigator" points="380.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="d7bb-920b-4964-d0d9" name="Twin-linked Castigator Pattern Bolt Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
@@ -2591,7 +2594,7 @@ Catastrophic Damage table.</description>
                 </link>
               </links>
             </entry>
-            <entry id="5a03-f5f1-fe23-830d" name="Cerastus Knight-Acheron" points="415.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="5a03-f5f1-fe23-830d" name="Cerastus Knight-Acheron" points="415.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="10ad-c3a1-8815-ef25" name="Acheron Pattern Flame Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
@@ -2725,7 +2728,7 @@ Catastrophic Damage table.</description>
                 </link>
               </links>
             </entry>
-            <entry id="0b47-71aa-cbd8-41dc" name="Cerastus Knight-Atrapos" points="435.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="0b47-71aa-cbd8-41dc" name="Cerastus Knight-Atrapos" points="435.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
                 <entry id="29cb-8b96-5c80-a336" name="Graviton Singularity Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
@@ -2781,21 +2784,6 @@ Catastrophic Damage table.</description>
                     </profile>
                   </profiles>
                   <links/>
-                </entry>
-                <entry id="0de6-b0c6-7ab0-f0e1" name="Warlord/Lord Baron" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="edb8-752f-8409-23d9" targetId="06869047-74f1-cdcb-92c0-acdeb21f8585" linkType="entry">
-                      <modifiers/>
-                    </link>
-                    <link id="40a3-1925-ae88-aaeb" targetId="df85-e304-d59a-e936" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
                 </entry>
                 <entry id="2712-f8b0-a556-28a9" name="Ionic Flare Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
@@ -2855,7 +2843,20 @@ Catastrophic Damage table.</description>
                     <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="7"/>
                     <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-heavy Walker)"/>
                   </characteristics>
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="increment" field="5ee4ff0b-b244-4670-9d05-91d10f80c32e" value="1" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="06869047-74f1-cdcb-92c0-acdeb21f8585" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" value="1" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="06869047-74f1-cdcb-92c0-acdeb21f8585" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Vehicle (Super-heavy Walker, Character)" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="06869047-74f1-cdcb-92c0-acdeb21f8585" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                 </profile>
                 <profile id="f73b-6508-001a-2495" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Blessed Autosimulacra" hidden="false" book="" page="0">
                   <characteristics>
@@ -2890,6 +2891,114 @@ Catastrophic Damage table.</description>
                   <modifiers/>
                 </link>
                 <link id="e411-512c-f345-5c8d" targetId="df85-e304-d59a-e936" linkType="entry group">
+                  <modifiers/>
+                </link>
+                <link id="3f45-7512-662d-a23a" targetId="06869047-74f1-cdcb-92c0-acdeb21f8585" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="44e4-4219-f406-fef1" name="Questoris Knight Porphyrion" points="435.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP">
+              <entries>
+                <entry id="670c-e8ce-1a75-13cd" name="Twin-linked magna-lascannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="43af-5729-475a-6ee3" targetId="f477-6198-c2fd-ac42" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="e21b-ce41-646b-44b4" name="Autocannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="63c8-0dc9-aa47-185b" targetId="93b9-0d9b-6084-7afc" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="0856-5f8c-dcc6-b050" name="Ironstorm Missile pod" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="efc7-8650-a2bf-2a90" targetId="0214-9c20-218e-c168" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="cf15-7fbc-d72d-37b6" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Questoris Knight Porphyrion" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+                  <characteristics>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+                    <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="14"/>
+                    <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+                    <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="12"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                    <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="7"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-heavy Walker)"/>
+                  </characteristics>
+                  <modifiers>
+                    <modifier type="set" field="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Vehicle (Super-heavy Walker, Character)" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="06869047-74f1-cdcb-92c0-acdeb21f8585" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" value="1" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="06869047-74f1-cdcb-92c0-acdeb21f8585" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="5ee4ff0b-b244-4670-9d05-91d10f80c32e" value="1" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="06869047-74f1-cdcb-92c0-acdeb21f8585" incrementField="selections" incrementValue="1.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                </profile>
+              </profiles>
+              <links>
+                <link id="559d-8881-9bdd-e13e" targetId="e88ec150-5af2-d671-2eb0-4721adc08718" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="d325-88fb-4d69-3bfc" targetId="8704d347-a524-60c5-c355-8da0db8ce81d" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="38de-9127-0306-80e0" targetId="1bcd2950-4532-f4a0-f11c-5592432e1726" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="3b90-cb4d-db2b-3bab" targetId="583b-5633-3e74-fc2c" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="c4f7-e766-2633-558c" targetId="588d8b33-e680-055d-fbe4-c789f3d141bc" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="15d0-7465-4aa2-80f7" targetId="88afb577-5b38-ea82-9c67-2de981ceda6c" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="bc07-8a18-9910-00ab" targetId="b6dc93c5-d2ce-94f9-c891-b00fb63e5336" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="88a7-151a-d948-7deb" targetId="3dfc7c03-90f5-c3ed-8e91-e799b67a745c" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="ea3b-afe3-23f1-f5eb" targetId="06869047-74f1-cdcb-92c0-acdeb21f8585" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="da2a-4734-2d6b-0c37" targetId="df85-e304-d59a-e936" linkType="entry group">
                   <modifiers/>
                 </link>
               </links>
@@ -4626,7 +4735,7 @@ If a unit with this special rule is deployed inside a Dedicated Transport, it co
       <profiles/>
       <links/>
     </entry>
-    <entry id="f79d-0b23-6323-b01a" name="Questoris Knight Magaera (War Conv.)" points="395.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="0" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="" page="0">
+    <entry id="f79d-0b23-6323-b01a" name="Questoris Knight Magaera (War Conv.)" points="395.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="" page="0">
       <entries>
         <entry id="7abf-03e4-a83f-7fdc" name="Phased Plasma-fusil" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -4833,6 +4942,127 @@ If a unit with this special rule is deployed inside a Dedicated Transport, it co
           <modifiers/>
         </link>
         <link id="8601-07a6-672a-5cd2" targetId="1bcd2950-4532-f4a0-f11c-5592432e1726" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="f8dc-86e2-e4d6-e434" name="Questoris Knight Porphyrion (War Conv.)" points="435.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Forgeworld WIP" page="Knight Porphyrion">
+      <entries>
+        <entry id="8cd3-cc97-ae69-2660" name="Warlord/Lord Baron" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="force type" childId="a134-a3af-0d96-1037" field="selections" type="instance of" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="1782-db05-57f9-eb81" targetId="06869047-74f1-cdcb-92c0-acdeb21f8585" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="c690-df14-929f-d871" targetId="df85-e304-d59a-e936" linkType="entry group">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="94fd-4c8d-7298-ecd7" name="Twin-linked magna-lascannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="cc31-4e55-7f6e-1677" targetId="f477-6198-c2fd-ac42" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="4cfb-ca40-d801-f5c6" name="Autocannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="9aa7-77b4-08fc-df57" targetId="93b9-0d9b-6084-7afc" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="c282-153d-7616-c535" name="Ironstorm Missile pod" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="8ef7-19f5-b876-92df" targetId="0214-9c20-218e-c168" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers>
+        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition parentId="roster" childId="293e-a1f1-b60c-cec9" field="selections" type="equal to" value="1.0"/>
+                <condition parentId="force type" childId="81dd-7ca3-059c-eaa7" field="selections" type="instance of" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <rules/>
+      <profiles>
+        <profile id="dab2-2e90-83b8-ab52" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Questoris Knight Porphyrion" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="14"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="12"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="7"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-heavy Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="9cd1-852a-80fa-aa10" targetId="e88ec150-5af2-d671-2eb0-4721adc08718" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6e6d-b0e5-f0e7-92f2" targetId="8704d347-a524-60c5-c355-8da0db8ce81d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cb2a-ad41-b484-1105" targetId="1bcd2950-4532-f4a0-f11c-5592432e1726" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="54dd-4304-d580-d6bc" targetId="583b-5633-3e74-fc2c" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="8d57-33ff-9b6f-39fb" targetId="588d8b33-e680-055d-fbe4-c789f3d141bc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1bfd-81e7-50da-a0e7" targetId="88afb577-5b38-ea82-9c67-2de981ceda6c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1679-9568-ca6f-a157" targetId="b6dc93c5-d2ce-94f9-c891-b00fb63e5336" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5f89-fba9-99be-f86d" targetId="3dfc7c03-90f5-c3ed-8e91-e799b67a745c" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -5597,6 +5827,9 @@ Knight Crusader - Precision Bombardment: Blast weapons fired by models in this F
       <modifiers/>
     </link>
     <link id="bba9-f007-21da-b580" targetId="21f2-5614-1166-84d9" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="f442-3fdc-3411-e2b3" targetId="6a37-7a24-962b-5d8c" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
       <modifiers/>
     </link>
   </links>
@@ -6911,7 +7144,7 @@ Catastrophic Damage table.</description>
         </link>
       </links>
     </entry>
-    <entry id="17ee-cd8e-8b95-3d38" name="Questoris Knight Magaera" points="395.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="0" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
+    <entry id="17ee-cd8e-8b95-3d38" name="Questoris Knight Magaera" points="395.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
       <entries>
         <entry id="d593-13aa-0e31-2a69" name="Phased Plasma-fusil" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7118,6 +7351,127 @@ Catastrophic Damage table.</description>
           <modifiers/>
         </link>
         <link id="3e9f-a5f7-2778-f0dc" targetId="1bcd2950-4532-f4a0-f11c-5592432e1726" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="6a37-7a24-962b-5d8c" name="Questoris Knight Porphyrion" points="435.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP">
+      <entries>
+        <entry id="25cd-02a1-e2bf-426b" name="Warlord/Lord Baron" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="force type" childId="a134-a3af-0d96-1037" field="selections" type="instance of" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="b360-a8aa-5701-7864" targetId="06869047-74f1-cdcb-92c0-acdeb21f8585" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="dc4e-caaa-53a2-de83" targetId="df85-e304-d59a-e936" linkType="entry group">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="6127-cd96-3fd4-eed5" name="Twin-linked magna-lascannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="1110-4411-8a38-4a52" targetId="f477-6198-c2fd-ac42" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="0bfe-faf9-df9f-b12d" name="Autocannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="29f9-7cec-dc1d-66ac" targetId="93b9-0d9b-6084-7afc" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="48b0-e0f7-05a3-812c" name="Ironstorm Missile pod" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="0387-deee-af3a-ee7d" targetId="0214-9c20-218e-c168" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers>
+        <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition parentId="force type" childId="81dd-7ca3-059c-eaa7" field="selections" type="instance of" value="0.0"/>
+                <condition parentId="force type" childId="293e-a1f1-b60c-cec9" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <rules/>
+      <profiles>
+        <profile id="a034-43f7-7195-a315" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Questoris Knight Porphyrion" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="14"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="12"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="7"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-heavy Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7df0-363f-7ef5-e373" targetId="e88ec150-5af2-d671-2eb0-4721adc08718" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="46e0-dd5a-1de9-4319" targetId="8704d347-a524-60c5-c355-8da0db8ce81d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6566-404a-be11-7fa4" targetId="1bcd2950-4532-f4a0-f11c-5592432e1726" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a95a-a030-2c9c-f974" targetId="583b-5633-3e74-fc2c" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="a66b-922f-8921-29a3" targetId="588d8b33-e680-055d-fbe4-c789f3d141bc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a4bc-49b4-7003-0fc7" targetId="88afb577-5b38-ea82-9c67-2de981ceda6c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3261-38a9-e2d0-64ae" targetId="b6dc93c5-d2ce-94f9-c891-b00fb63e5336" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a6c4-9b8e-628e-2a80" targetId="3dfc7c03-90f5-c3ed-8e91-e799b67a745c" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -7441,6 +7795,15 @@ In addition, any attacks or special abilities that permanently lower the Armour 
     </rule>
   </sharedRules>
   <sharedProfiles>
+    <profile id="93b9-0d9b-6084-7afc" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Autocannon" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
     <profile id="817b-b4c6-e764-ab4f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Avenger Gatling Cannon" hidden="false">
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
@@ -7474,12 +7837,30 @@ In addition, any attacks or special abilities that permanently lower the Armour 
       </characteristics>
       <modifiers/>
     </profile>
+    <profile id="0214-9c20-218e-c168" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Ironstorm Missile Pod [FW]" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="72&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 1, Large Blast"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
     <profile id="5f69-ab5b-ac3d-aebe" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Ironstorm Missle Pod" hidden="false">
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="72&quot;"/>
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
         <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
         <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Large Blast, Barrage"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="f477-6198-c2fd-ac42" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Magna-lascannon" hidden="false" book="Forgeworld WIP" page="Knight Porphyrion">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="72&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="10"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 2, Large Blast"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
Updated Imperial Knights Catalog to include the Forgeworld Work in
Progress - Questoris Knight Porphyrion w/Modified missile pod.
Added additional profiles to cover current WIP stats for weapons.
Closed #1865

Cleaned up Maximum number of Questoris Knight selections for forge
world Knight Magera/Lancer/Castigator/Acheron/Atropos

Updated exalted court logic to handle upgrading knights to warlord with
threaded stats.
