### PR TITLE
Added Bonding Knife as requirement to Crisis Suits

### DIFF
--- a/Tau - Codex (2015).cat
+++ b/Tau - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24a0-49b6-ecef-1c5a" revision="19" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="23" battleScribeVersion="1.15" name="Tau Empire: Codex (2015)" books="Codex: Tau Empire, Kau&apos;yon, Mont&apos;ka" authorName="Eric Falsken" authorContact="eric@everylittlething.net" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24a0-49b6-ecef-1c5a" revision="20" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="23" battleScribeVersion="1.15" name="Tau Empire: Codex (2015)" books="Codex: Tau Empire, Kau&apos;yon, Mont&apos;ka" authorName="Eric Falsken" authorContact="eric@everylittlething.net" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="624c35d9-cb7e-26b8-1d3a-77a4bc324d57" name="Ambush Spearhead" points="75.0" categoryId="38cf4ccf-0665-45cb-a773-fea06ee1467a" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Spearhead_Expansion.pdf" page="11">
       <entries/>
@@ -13248,6 +13248,12 @@ Vector Evasion: The model gains the Jink special rule, and when Thrusting or Swo
           <modifiers>
             <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="f0fbbf26-a0db-4f38-8a3b-fd549232910e" incrementChildId="7307e725-3bb0-0dcf-a285-a8ad18c5d609" incrementField="selections" incrementValue="1.0">
               <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="force type" childId="568b-407f-d02c-8161" field="selections" type="at least" value="1.0"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>


### PR DESCRIPTION
Added Bonding Knife as requirement to Crisis Suits when using Farsight Enclaves
