### PR TITLE
Fixes for Ironwolves formation and Vehicle Squadrons

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="53" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="54" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="bb9b8beb-6b7d-a571-f99d-6cb94dd920ff" name="&quot;Great Company&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves">
       <entries>
@@ -29762,12 +29762,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="f16d-0c2d-4d49-e534" name="Pack" minSelections="5" maxSelections="15" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="f16d-0c2d-4d49-e534" name="Pack" defaultEntryId="744a-9f17-a276-a840" minSelections="5" maxSelections="15" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="744a-9f17-a276-a840" name="Blood Claw" points="12.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="15" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
                       <entryGroups>
-                        <entryGroup id="d7a2-3b29-b2ab-5c86" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                        <entryGroup id="d7a2-3b29-b2ab-5c86" name="Melee Weapon" defaultEntryId="5f3e-7ea5-8267-30e9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
                           <entries>
                             <entry id="5f3e-7ea5-8267-30e9" name="Chainsword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="15" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -30463,12 +30463,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="4679-2a03-ffee-ad40" name="Pack" minSelections="5" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="4679-2a03-ffee-ad40" name="Pack" defaultEntryId="fd17-0435-e6c5-9916" minSelections="5" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="fd17-0435-e6c5-9916" name="Grey Hunter" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
                       <entryGroups>
-                        <entryGroup id="aec7-8894-6f18-ed73" name="Bolt Pistol" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                        <entryGroup id="aec7-8894-6f18-ed73" name="Bolt Pistol" defaultEntryId="749e-5c4b-6f60-ec27" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
                           <entries>
                             <entry id="d4cc-8a73-7c02-d6da" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -30567,7 +30567,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                           <modifiers/>
                           <links/>
                         </entryGroup>
-                        <entryGroup id="668e-f905-5002-6d9c" name="Bolter" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                        <entryGroup id="668e-f905-5002-6d9c" name="Bolter" defaultEntryId="0072-40ed-af3f-1391" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
                           <entries>
                             <entry id="86e4-9461-5602-bfed" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -30782,7 +30782,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                 <entry id="eb2e-d151-fd43-5b42" name="Land Speeder" points="50.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
                   <entryGroups>
-                    <entryGroup id="c83d-cc9c-3ffb-a4ca" name="Main Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                    <entryGroup id="c83d-cc9c-3ffb-a4ca" name="Main Weapon" defaultEntryId="7745-e401-23eb-c381" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                       <entries>
                         <entry id="ebe2-9d35-75c0-4da5" name="Multi-melta" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                           <entries/>
@@ -31302,7 +31302,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="b8b3-887b-cf39-9e43" name="Ancient" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="b8b3-887b-cf39-9e43" name="Ancient" defaultEntryId="8c24-46ee-02e6-38fa" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="8c24-46ee-02e6-38fa" name="Long Fang Ancient" points="15.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
@@ -31606,7 +31606,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="2da6-9b0d-0b0d-d533" name="Heavy Weapons" minSelections="1" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="2da6-9b0d-0b0d-d533" name="Heavy Weapons" defaultEntryId="23ee-5cd1-1114-75e5" minSelections="1" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="fa85-dbfb-a79f-ec16" name="Long Fang w/ Heavy Bolter" points="25.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>

--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="52" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="53" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="bb9b8beb-6b7d-a571-f99d-6cb94dd920ff" name="&quot;Great Company&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves">
       <entries>
@@ -22450,7 +22450,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
     </entry>
     <entry id="c739de81-036b-4e6e-a10f-9dcaa9d67836" name="Land Speeder Squadron" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="79">
       <entries>
-        <entry id="41af90bb-d065-ad16-def6-f4f10da051e4" name="Land Speeder" points="50.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="41af90bb-d065-ad16-def6-f4f10da051e4" name="Land Speeder" points="50.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="79">
           <entries/>
           <entryGroups>
             <entryGroup id="eb696f76-709d-49f7-8ee6-25fd343009df" name="Main Weapon" defaultEntryId="ce959a62-650a-5666-cda8-e444bd3f62df" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -22587,7 +22587,11 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <modifiers/>
       <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="9dde-7b79-17dd-0af7" targetId="47fc-1bf0-078a-d1ce" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="7f203e44-a050-6142-d541-49f745009497" name="Lascannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
       <entries/>
@@ -24728,89 +24732,102 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="71b3838f-2507-0dae-113a-2c38b0710d0c" name="Predator Squadron" points="75.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="84">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c0278ec0-d096-bc03-e864-0532472e239f" name="Turret Weapon" defaultEntryId="c9d6b278-2c19-ab00-3a6d-afea5a11c733" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="4fadb111-356e-f3d8-ec77-db616b5a2c31" name="Twin-linked Lascannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
+    <entry id="71b3838f-2507-0dae-113a-2c38b0710d0c" name="Predator Squadron" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="29">
+      <entries>
+        <entry id="65d5-a854-f24c-df4b" name="Predator" points="75.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="84">
+          <entries/>
+          <entryGroups>
+            <entryGroup id="0cc4-322d-dea8-bbbe" name="Sponson Weapons" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="70c0-1873-8959-2295" name="2x Lascannons" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="4238-0c55-16c5-8cfd" targetId="4944e4f5-94fb-d71d-5137-0114b4be41e1" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="c1f7-96e3-260f-45f2" name="2x Heavy Bolters" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="bca9-682a-0502-f2f7" targetId="86ab4a73-4680-4c6a-007d-3c6823bd2599" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
               <entryGroups/>
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c680193b-556d-7542-c3b6-bcfe712cae05" targetId="4944e4f5-94fb-d71d-5137-0114b4be41e1" linkType="profile">
+              <links/>
+            </entryGroup>
+            <entryGroup id="50f1-18e0-7c9c-e42e" name="Turret Weapon" defaultEntryId="620c-340e-ed23-32c4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="05e4-4a0d-8bce-c2c9" name="Twin-linked Lascannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="c9d6b278-2c19-ab00-3a6d-afea5a11c733" name="Autocannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="9c30-df40-69fe-d52f" targetId="4944e4f5-94fb-d71d-5137-0114b4be41e1" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="620c-340e-ed23-32c4" name="Autocannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="8821-3342-0148-bd85" targetId="6f807806-1dc8-a300-0978-8c1eb8ef0e53" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
               <entryGroups/>
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="48eab3ed-dd43-a4f9-06f1-3546aa2fe4bc" targetId="6f807806-1dc8-a300-0978-8c1eb8ef0e53" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
           <modifiers/>
-          <links/>
-        </entryGroup>
-        <entryGroup id="343bf774-b2a6-43fd-5eaa-b8976bd49966" name="Sponson Weapons" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ff36acb6-2b8f-8f0c-4e30-6b0a7793b7d7" name="2x Lascannons" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="9790-4f61-25cc-aa78" targetId="6ce273e9-d331-0fd8-7c30-57c22d366db2" linkType="profile">
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a5a8c447-cf50-2b8e-13c7-e4996023bd52" targetId="4944e4f5-94fb-d71d-5137-0114b4be41e1" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="eb452729-58ae-d726-a329-ef3026136fd2" name="2x Heavy Bolters" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
+            </link>
+            <link id="3e19-9f52-d9b5-6b03" targetId="4f134a9a-cc8e-1728-ed6a-346c4fefab8d" linkType="entry group">
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="df2f8cc3-43f6-525d-2b35-9e0b2c05b4e6" targetId="86ab4a73-4680-4c6a-007d-3c6823bd2599" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
+            </link>
+            <link id="e851-092f-d05d-4d43" targetId="7f289607-0f4f-2a48-b7b1-975423d633d4" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="427d-0f1a-948c-9072" targetId="7aeea2dc-d28f-94d7-deea-ba921a968e2a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="99bb-c019-9e89-a09a" targetId="c23dbe20-6e87-1b1e-462e-4bd050161057" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
       <links>
-        <link id="246b7a8d-4927-81d8-58c8-9c7f8f3adf3c" targetId="4f134a9a-cc8e-1728-ed6a-346c4fefab8d" linkType="entry group">
-          <modifiers/>
-        </link>
-        <link id="7e70e233-38d3-006f-9b6d-c8f1c09d34e4" targetId="6ce273e9-d331-0fd8-7c30-57c22d366db2" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="556e1828-8e18-6576-75f8-0f87da3706b3" targetId="7f289607-0f4f-2a48-b7b1-975423d633d4" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="0fa5c75b-b739-1af9-d513-942eb4b9d809" targetId="7aeea2dc-d28f-94d7-deea-ba921a968e2a" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="21f5e647-b119-115a-d06d-ffeb4b4c2e33" targetId="c23dbe20-6e87-1b1e-462e-4bd050161057" linkType="entry">
+        <link id="01ea-f155-944b-2890" targetId="b4a2-aa20-d4d7-e385" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -32430,86 +32447,99 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="4a7d6494-e65e-4bd4-84ae-d3218204658d" name="Vindicator Squadron" points="120.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="82">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="d8589651-ce05-b54b-25d2-d4639ce39db2" name="Vehicle Upgrades" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="1aaa0fe4-99d5-832c-77ef-3b4ea6d811f7" name="Extra Armour" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="31a05ffb-4dad-a753-0909-cac50733269b" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a81f7935-48f1-16ea-9d34-2bf0fc691e22" name="Storm Bolter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5241b98c-7eb9-77d1-320a-316cda079bba" targetId="a2da2b98-1a14-9a16-f860-077c1544545d" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+    <entry id="4a7d6494-e65e-4bd4-84ae-d3218204658d" name="Vindicator Squadron" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="28">
+      <entries>
+        <entry id="b8d8-0f3c-2425-1b83" name="Vindicator" points="120.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="82">
+          <entries/>
           <entryGroups>
-            <entryGroup id="5484b182-267a-349c-16d5-e6478e714005" name="Plough" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entryGroup id="7fc6-a5f2-2ed0-a6da" name="Vehicle Upgrades" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
-                <entry id="94e526d0-d4d9-6fc5-623c-37dcbdd79cfa" name="Siege Shield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                <entry id="fbef-52d7-bddb-b8bd" name="Extra Armour" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
                   <rules/>
                   <profiles/>
                   <links>
-                    <link id="ebe6612b-b9b7-ebbd-65d4-df7aa8ab9e4e" targetId="6d064663-3a04-b317-8a74-89043943de59" linkType="profile">
+                    <link id="a937-2338-1832-4564" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="4f1e-b421-f7e6-a2e9" name="Storm Bolter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="dfd1-49f9-eda2-0b15" targetId="a2da2b98-1a14-9a16-f860-077c1544545d" linkType="profile">
                       <modifiers/>
                     </link>
                   </links>
                 </entry>
               </entries>
-              <entryGroups/>
+              <entryGroups>
+                <entryGroup id="37b8-6ac2-8aa3-d92d" name="Plough" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="ec25-0dca-0fea-d072" name="Siege Shield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="28f8-50a7-a819-37b8" targetId="6d064663-3a04-b317-8a74-89043943de59" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links>
+                    <link id="c86c-4822-1e81-391a" targetId="7d9dc261-8094-d24a-09d1-bc213a7488af" linkType="entry">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entryGroup>
+              </entryGroups>
               <modifiers/>
               <links>
-                <link id="3176f0b0-5d58-8ec8-d4a6-c474c87e43f2" targetId="7d9dc261-8094-d24a-09d1-bc213a7488af" linkType="entry">
+                <link id="3c34-9d4e-b5e0-9f20" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
                   <modifiers/>
                 </link>
               </links>
             </entryGroup>
           </entryGroups>
           <modifiers/>
+          <rules/>
+          <profiles/>
           <links>
-            <link id="8deb4087-22b5-f4ef-4cf8-3ef4fbc2c140" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
+            <link id="d887-8fa3-5e72-3f5a" targetId="efc3d812-9412-3d70-4ad4-0241c4ce4ab3" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="9169-28b6-cc96-81df" targetId="7f289607-0f4f-2a48-b7b1-975423d633d4" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="26f7-2b39-e516-f1a2" targetId="7aeea2dc-d28f-94d7-deea-ba921a968e2a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="97d5-2347-010e-f171" targetId="c23dbe20-6e87-1b1e-462e-4bd050161057" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="2af4-0c86-50a9-e769" targetId="565d77ae-18cb-fc10-1738-72ab1ca56538" linkType="profile">
               <modifiers/>
             </link>
           </links>
-        </entryGroup>
-      </entryGroups>
+        </entry>
+      </entries>
+      <entryGroups/>
       <modifiers/>
       <rules/>
       <profiles/>
       <links>
-        <link id="9244d13f-7da6-58c6-5f0b-336bff0c3d96" targetId="565d77ae-18cb-fc10-1738-72ab1ca56538" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="a253901d-3991-52c6-af5c-f9699d35e3fb" targetId="7f289607-0f4f-2a48-b7b1-975423d633d4" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="1200e7a9-af93-7c89-ef8e-c9c737439b22" targetId="c23dbe20-6e87-1b1e-462e-4bd050161057" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="b325a2b2-2b1a-cb27-51ff-ae8fb83af4f3" targetId="7aeea2dc-d28f-94d7-deea-ba921a968e2a" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="3339f22e-9be8-7de4-5f1c-5a9614875c75" targetId="efc3d812-9412-3d70-4ad4-0241c4ce4ab3" linkType="entry">
+        <link id="40d5-c9d5-4507-421d" targetId="e546-a644-7fb2-1908" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -32606,19 +32636,44 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="5a00c5d0-8d06-4074-a230-23111830b954" name="Whirlwind Squadron" points="65.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="83">
+    <entry id="5a00c5d0-8d06-4074-a230-23111830b954" name="Whirlwind Squadron" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="29">
       <entries>
-        <entry id="22c7f2bf-8bdc-e2dd-9f5a-5cb84a0dfda0" name="Whirlwind Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
+        <entry id="b54d-f303-8364-d8dd" name="Whirlwind" points="65.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="83">
+          <entries>
+            <entry id="5ea6-94ee-d38b-fc99" name="Whirlwind Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="ff00-51ff-19b7-76e5" targetId="a6e6a512-be7f-73ad-9c7b-3ed1b3277e99" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="4e3a-fc8f-598d-4d2c" targetId="58d05bb2-0482-77b6-4353-2d7ff9306e6b" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
           <entryGroups/>
           <modifiers/>
           <rules/>
           <profiles/>
           <links>
-            <link id="10a94ab1-7baf-4f2b-bcea-5ab9a7784993" targetId="a6e6a512-be7f-73ad-9c7b-3ed1b3277e99" linkType="profile">
+            <link id="3e0a-a1de-4b79-c20b" targetId="7f289607-0f4f-2a48-b7b1-975423d633d4" linkType="entry">
               <modifiers/>
             </link>
-            <link id="03ea30ee-9108-beeb-4bae-625ba92d1ccc" targetId="58d05bb2-0482-77b6-4353-2d7ff9306e6b" linkType="profile">
+            <link id="a3bd-1274-1d23-2286" targetId="7aeea2dc-d28f-94d7-deea-ba921a968e2a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="68f2-5d32-1817-2eed" targetId="c23dbe20-6e87-1b1e-462e-4bd050161057" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="f579-2cea-9a57-c239" targetId="4f134a9a-cc8e-1728-ed6a-346c4fefab8d" linkType="entry group">
+              <modifiers/>
+            </link>
+            <link id="eadd-22ca-525b-8700" targetId="009ff154-d90a-7977-44d4-3d34d10a1337" linkType="profile">
               <modifiers/>
             </link>
           </links>
@@ -32629,19 +32684,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <rules/>
       <profiles/>
       <links>
-        <link id="a9600369-d62c-988d-68bc-77d61e769430" targetId="4f134a9a-cc8e-1728-ed6a-346c4fefab8d" linkType="entry group">
-          <modifiers/>
-        </link>
-        <link id="fed13ef7-ef24-19e7-16a1-27e87bfc1499" targetId="009ff154-d90a-7977-44d4-3d34d10a1337" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="80a8ead7-49b5-b265-970c-ff4fd7d51531" targetId="7f289607-0f4f-2a48-b7b1-975423d633d4" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7a7818bd-3ecb-5801-ed37-59dfcf0b1359" targetId="7aeea2dc-d28f-94d7-deea-ba921a968e2a" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="e55f5089-c056-5907-6d67-e0643f7c8c03" targetId="c23dbe20-6e87-1b1e-462e-4bd050161057" linkType="entry">
+        <link id="dc7e-6179-c4e6-9931" targetId="1922-acc1-f9eb-28f5" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -41020,6 +41063,10 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
     <rule id="db0f0c32-584c-e438-2f7f-d4e5762597f2" name="Animal Rage" hidden="false" book="GW pdf datasheet" page="0">
       <modifiers/>
     </rule>
+    <rule id="47fc-1bf0-078a-d1ce" name="Anti-grav Upwash" hidden="false" book="Curse of the Wulfen" page="29">
+      <description>Whilst this unit includes three Land Speeders, it can move an additional 6&quot; when moving Flat Out.</description>
+      <modifiers/>
+    </rule>
     <rule id="5317607a-3f17-ac41-76bc-3552cd4db4a2" name="Apocalyptic Barrage" hidden="false" book="IA Aeronautica" page="0">
       <modifiers/>
     </rule>
@@ -41396,6 +41443,10 @@ Having Infiltrate also confers the Outflank special rule to units of Infiltrator
     <rule id="1dfa9eb3-b07c-609a-754d-b13555267c17" name="Killshot" hidden="false" book="40k Apocalypse 2nd Ed" page="0">
       <modifiers/>
     </rule>
+    <rule id="b4a2-aa20-d4d7-e385" name="Killshot (Predator Squadron)" hidden="false" book="Curse of the Wulfen" page="29">
+      <description>Whilst this unit includes three Predators, all Predators in the unit have the Monster Hunter and Tank Hunters special rules.</description>
+      <modifiers/>
+    </rule>
     <rule id="06f450df-e80c-eb11-efe2-3808f6891556" name="Kingsguard" hidden="true" book="Champions of Fenris">
       <description>The following models have +1 WS on their profile when chosen as part of this Detachment:
 - Wolf Guard
@@ -41458,6 +41509,10 @@ Having Infiltrate also confers the Outflank special rule to units of Infiltrator
       <modifiers/>
     </rule>
     <rule id="d490888d-9ddd-3598-b7f4-eb791f2a3d80" name="Legacies of Glory: War of Murder" hidden="false" book="Imperial Armour II 2nd Ed" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="e546-a644-7fb2-1908" name="Linebreaker Bombardment" hidden="false" book="Curse of the Wulfen" page="28">
+      <description>If this unit contains three Vindicators that can all fire their demolisher cannons, the squadron can fire a single Linebreaker Bombardment instead of firing normally. To do so, nominate one model in the squadron as the firer; the firers demolisher cannon changes its type from Large Blast to Apocalyptic Blast and gains the Ignores Cover special rule.</description>
       <modifiers/>
     </rule>
     <rule id="910ed967-1bab-f843-923b-2681d933b68b" name="Living Legend" hidden="false" page="0">
@@ -41882,6 +41937,10 @@ Cover save bonuses from the Shrouded and Stealth special rules are cumulative (t
       <modifiers/>
     </rule>
     <rule id="381bb905-a0f2-f66b-13ee-74bbf271a5cf" name="Supersonic" hidden="false" book="Warhammer 40k rulebook" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="1922-acc1-f9eb-28f5" name="Suppressive Bombardment" hidden="false" book="Curse of the Wulfen" page="29">
+      <description>Whilst this unit includes three Whirlwinds, each model&apos;s Whirlwind multiple missile launcher has the Pinning and Shred special rules (regardless of which missile type it fires).</description>
       <modifiers/>
     </rule>
     <rule id="35304385-a7d6-ccf1-f66a-8460cadceb7d" name="Swift Strike" hidden="false" book="lancer.pdf" page="0">

--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="51" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="52" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="bb9b8beb-6b7d-a571-f99d-6cb94dd920ff" name="&quot;Great Company&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves">
       <entries>
@@ -21746,6 +21746,85 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="dca0-9ecd-b61f-b15a" name="Harald Deathwolf, Lord of the Wolfkin" points="190.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="50">
+      <entries>
+        <entry id="c03c-52f8-2980-d4c2" name="Frost Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="c91d-6117-d0f0-89e6" targetId="8a52ed78-8139-b06a-2f9e-c574962705b6" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="0306-6c94-2915-4444" name="Relic: Mantle of the Ice Troll King" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="97e4-a177-ad3d-621c" targetId="7f4045ec-808f-b7b5-9261-acce421cdf14" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="b0ef-28bd-bba1-e7e8" targetId="dbca7f53-0ee4-9441-a689-02f0b2a1cc43" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="6809-1bee-a198-b9ce" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="07d2-67bd-973d-7586" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b29b-1733-9df5-69a7" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="64cb-cfbe-2b57-868c" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0ed7-3e4b-0cd3-be12" targetId="7ae778b2-8ebc-ffde-bdbe-cbfcb6675c9d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="618e-2d32-a634-6378" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="8ddc-7d8c-5fe1-5919" targetId="233e6766-e598-f204-c36f-f400348f38dc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1b05-4be4-f810-67cd" targetId="23c483d1-b5ec-5348-487f-befd40201037" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8c85-d342-45fc-0079" targetId="e9cfe9f3-9259-1e61-7c53-9f6147e5bee9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="96f6-d164-8de6-fd4d" targetId="791149d1-ea3f-3e5e-3390-f36857a6794d" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="5a35-1f54-a2b4-2a6e" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="8299-30f0-fc24-6e97" targetId="d3fb2835-5b64-beb7-c844-df8ddc84a8ac" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="5b9f-4095-81ac-30df" targetId="5a2ea81e-b2dc-c9f1-b755-16fa94f7f90e" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="104c-080c-d7c4-fa8d" targetId="839e7904-8031-eb38-f7c8-c235b0b7a6bc" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="cd80cfe6-82b6-8d85-4313-9ee4aefecf4a" name="Healing Balms" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups/>
@@ -23451,6 +23530,109 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </link>
         <link id="48fe69ab-4bd6-0732-6973-ddbb1c3f1cfc" targetId="791149d1-ea3f-3e5e-3390-f36857a6794d" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="414b-dad2-61d6-05bd" name="Lone Wolf (no force org)" points="20.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="0" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="65">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="b1c3-0f7f-c326-5291" name="Armour" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="85d9-143f-396b-3643" name="Terminator Armour" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="9865-274b-96a7-7a93" targetId="77cd0765-7ddf-d654-cc86-3de641888ae3" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="536a-d199-881f-6945" targetId="7019797e-4a54-e56f-8e3f-f3167a57ac83" linkType="entry group">
+                  <modifiers/>
+                </link>
+                <link id="490e-2618-e589-5d00" targetId="3fd8507c-f2b1-7d3f-ff2a-fbb99353977c" linkType="entry group">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="12d8-75c6-e9fd-c3b7" name="Power Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="a39f-1e87-af2b-8543" targetId="0adf24a5-2133-fdb4-9999-2e1d3ad01439" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="7b85-73cd-4a3d-2741" targetId="a8d2-8ef8-07ba-b5b3" linkType="entry group">
+                  <modifiers/>
+                </link>
+                <link id="59ac-1eb7-dfcf-9897" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers>
+        <modifier type="increment" field="maxInRoster" value="1.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="75747f46-5328-674c-f7fd-b6107d182cf8" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="roster" childId="75747f46-5328-674c-f7fd-b6107d182cf8" field="selections" type="at least" value="1.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="b17c-5624-37ac-1b77" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e979-49fa-bc23-f250" targetId="47f277a2-4f52-c636-baaa-8e0af970ed69" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1c18-564b-3986-fb7c" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="17eb-86fd-1b9a-5687" targetId="8dfc345f-5d7b-c1ac-8870-4d14b8409352" linkType="profile">
+          <modifiers>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+/5++" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="414b-dad2-61d6-05bd" childId="85d9-143f-396b-3643" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="d82d-91bd-ae02-2537" targetId="9ddeb747-dd42-e0e3-df16-b524ad688ce0" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c989-55f8-0cea-efd1" targetId="be032c0b-31b0-03c7-8684-a4b645951889" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="54ce-c08b-e20b-b072" targetId="da615d3a-27e0-2504-7b73-80482f2af4f3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4ad8-6dec-ca55-ea01" targetId="5c931240-087a-3624-74d9-41572b0c32fd" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9e43-d11c-bff4-e572" targetId="2cf8a4e5-0c8f-254f-5616-fe557729ff58" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="10a4-f302-35a2-8139" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="16c0-f3ec-a91e-43f1" targetId="817d1d89-a150-658d-837c-02417b24437b" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="b90e-7383-6de6-49ae" targetId="791149d1-ea3f-3e5e-3390-f36857a6794d" linkType="entry">
           <modifiers/>
         </link>
       </links>
@@ -26458,6 +26640,21 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="39eb-cbaf-bca1-95e5" name="Tempest Hammer" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="8532-e14b-13fd-91c2" targetId="ea4c-7569-acba-851f" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="e0f4-5be4-188d-6f8c" targetId="da4cc1e9-9855-01d0-f968-d551470dce58" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="e9eab585-559a-97d2-d93a-34175389635a" name="Tempestas Discipline" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="1221fb43-487e-dde3-e5e2-ab1dc681eb15" name="Primaris Power - Living Lightning" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -27505,7 +27702,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="43a4-e93e-9d07-5be7" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="43a4-e93e-9d07-5be7" name="Transport" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="eb91-7f54-f345-f9d2" name="Drop Pod" points="35.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="74">
                       <entries>
@@ -28250,7 +28447,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                 </entry>
               </entries>
               <entryGroups>
-                <entryGroup id="a04d-9055-948a-7c7d" name="Wolf Guard Terminators Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="a04d-9055-948a-7c7d" name="Wolf Guard Terminators Transport" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="acf9-ab9b-2465-84c2" name="Stormwolf" points="215.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="75">
                       <entries>
@@ -29069,7 +29266,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             <entry id="d847-7f7d-ce50-8f93" name="Blood Claws" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="58">
               <entries/>
               <entryGroups>
-                <entryGroup id="c5a1-2eaa-5cad-2c85" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="c5a1-2eaa-5cad-2c85" name="Transport" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="415d-4455-1eca-7c51" name="Drop Pod" points="35.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="74">
                       <entries>
@@ -29770,7 +29967,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                 </entry>
               </entries>
               <entryGroups>
-                <entryGroup id="1a4d-8fdd-7ae7-c851" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="1a4d-8fdd-7ae7-c851" name="Transport" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="5d62-8e3a-931d-57e9" name="Drop Pod" points="35.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="74">
                       <entries>
@@ -30361,7 +30558,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                               <modifiers>
                                 <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                                   <conditions>
-                                    <condition parentId="9c46-2aba-c640-1fae" childId="8b52-c2bb-747a-4323" field="selections" type="equal to" value="1.0"/>
+                                    <condition parentId="9c46-2aba-c640-1fae" childId="86e4-9461-5602-bfed" field="selections" type="equal to" value="1.0"/>
                                   </conditions>
                                   <conditionGroups/>
                                 </modifier>
@@ -30505,7 +30702,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                               <modifiers>
                                 <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                                   <conditions>
-                                    <condition parentId="9c46-2aba-c640-1fae" childId="ee19-0ae0-975f-e6d9" field="selections" type="equal to" value="1.0"/>
+                                    <condition parentId="9c46-2aba-c640-1fae" childId="4c83-e215-e4f3-75bc" field="selections" type="equal to" value="1.0"/>
                                   </conditions>
                                   <conditionGroups/>
                                 </modifier>
@@ -30711,7 +30908,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             <entry id="13e1-b034-4868-5cc5" name="Long Fangs" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="81">
               <entries/>
               <entryGroups>
-                <entryGroup id="633f-be90-524d-f507" name="Transport" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="633f-be90-524d-f507" name="Transport" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="770e-74b2-e7ab-6699" name="Drop Pod" points="35.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="74">
                       <entries>
@@ -31689,13 +31886,16 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="5796-4876-ba77-6db5" name="Mobile Assault" hidden="false" book="Curse of the Wulfen">
+        <rule id="5796-4876-ba77-6db5" name="Mobile Assault" hidden="false" book="Curse of the Wulfen" page="37">
+          <description>Ironwolves units can disembark from their Transports even if the vehicle has moved up to 12&quot; in the Movement phase.</description>
           <modifiers/>
         </rule>
-        <rule id="6fef-f53c-cc37-95c9" name="Armoured Onslaught" hidden="false" book="Curse of the Wulfen">
+        <rule id="6fef-f53c-cc37-95c9" name="Armoured Onslaught" hidden="false" book="Curse of the Wulfen" page="37">
+          <description>All Ironwolves vehicles can move an additional 6&quot; when moving Flat Out. In addition, when taking Morale checks caused by Tank Shock from an Ironwolves vehicle, enemy units suffer a -2 penalty to their Leadership characteristic.</description>
           <modifiers/>
         </rule>
-        <rule id="00ed-bc7e-e4f7-e1ec" name="Overwhelming Firepower" hidden="false">
+        <rule id="00ed-bc7e-e4f7-e1ec" name="Overwhelming Firepower" hidden="false" book="Curse of the Wulfen" page="37">
+          <description>All weapon and wargear options taken by Ironwolves vehicles are free.</description>
           <modifiers/>
         </rule>
         <rule id="2787-daa5-ed96-e021" name="Validation for ironwolves" hidden="false">
@@ -33820,6 +34020,89 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="bfdc-f5c5-672a-f356" name="Wolf Lord Krom, The Fierce Eye" points="150.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="f273-fc68-0348-0c92" name="Wyrmclaw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="aa3d-9636-18b6-a1dd" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Wyrmclaw" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+2"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Master-crafted, Unwieldy"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="fbb0-cc5b-774b-bec5" name="Duty or Death" hidden="false">
+          <description>Krom can re-roll all failed saving throws when he is within 3&quot; of an Objective Marker.</description>
+          <modifiers/>
+        </rule>
+        <rule id="39b5-3c6b-8034-6934" name="The Fierce-eye" hidden="false">
+          <description>Krom can re-roll failed To Wound rolls in close combat</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="1749-e185-75da-853a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Wolf Lord Krom, The Fierce Eye" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character) "/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="8984-f5df-66f3-a00f" targetId="74d72175-8c6f-57a0-56d0-bb498cb5e030" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="df7c-df9a-7631-5c58" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="61ea-f4d4-f358-23fc" targetId="e9cfe9f3-9259-1e61-7c53-9f6147e5bee9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1b1d-af21-dfd0-da02" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="2892-5e27-5898-ce22" targetId="9ba00ec4-2c72-2463-c497-b706c5ab98f9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e3e8-bcd5-4cbe-8074" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1bfd-8b8a-9f30-cc21" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6abd-b3ea-6c98-a518" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="274d-ed28-1bc9-b521" targetId="98d356a2-8d8b-af1a-4228-90d7d1e6d45a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6a0a-1e30-5a82-c1bf" targetId="cb0122dd-c2e2-3881-4e57-4840e8f3346c" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="27e8fb45-f8e1-4455-8739-7a8f84debfdb" name="Wolf Priest" points="110.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="54">
       <entries/>
       <entryGroups>
@@ -34766,286 +35049,6 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
       <rules/>
       <profiles/>
       <links/>
-    </entry>
-    <entry id="414b-dad2-61d6-05bd" name="Lone Wolf (no force org)" points="20.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="0" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="65">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="b1c3-0f7f-c326-5291" name="Armour" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="85d9-143f-396b-3643" name="Terminator Armour" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9865-274b-96a7-7a93" targetId="77cd0765-7ddf-d654-cc86-3de641888ae3" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="536a-d199-881f-6945" targetId="7019797e-4a54-e56f-8e3f-f3167a57ac83" linkType="entry group">
-                  <modifiers/>
-                </link>
-                <link id="490e-2618-e589-5d00" targetId="3fd8507c-f2b1-7d3f-ff2a-fbb99353977c" linkType="entry group">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="12d8-75c6-e9fd-c3b7" name="Power Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a39f-1e87-af2b-8543" targetId="0adf24a5-2133-fdb4-9999-2e1d3ad01439" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="7b85-73cd-4a3d-2741" targetId="a8d2-8ef8-07ba-b5b3" linkType="entry group">
-                  <modifiers/>
-                </link>
-                <link id="59ac-1eb7-dfcf-9897" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="increment" field="maxInRoster" value="1.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="75747f46-5328-674c-f7fd-b6107d182cf8" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="75747f46-5328-674c-f7fd-b6107d182cf8" field="selections" type="at least" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b17c-5624-37ac-1b77" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="e979-49fa-bc23-f250" targetId="47f277a2-4f52-c636-baaa-8e0af970ed69" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1c18-564b-3986-fb7c" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="17eb-86fd-1b9a-5687" targetId="8dfc345f-5d7b-c1ac-8870-4d14b8409352" linkType="profile">
-          <modifiers>
-            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+/5++" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="414b-dad2-61d6-05bd" childId="85d9-143f-396b-3643" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="d82d-91bd-ae02-2537" targetId="9ddeb747-dd42-e0e3-df16-b524ad688ce0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c989-55f8-0cea-efd1" targetId="be032c0b-31b0-03c7-8684-a4b645951889" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="54ce-c08b-e20b-b072" targetId="da615d3a-27e0-2504-7b73-80482f2af4f3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4ad8-6dec-ca55-ea01" targetId="5c931240-087a-3624-74d9-41572b0c32fd" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9e43-d11c-bff4-e572" targetId="2cf8a4e5-0c8f-254f-5616-fe557729ff58" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="10a4-f302-35a2-8139" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="16c0-f3ec-a91e-43f1" targetId="817d1d89-a150-658d-837c-02417b24437b" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="b90e-7383-6de6-49ae" targetId="791149d1-ea3f-3e5e-3390-f36857a6794d" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="39eb-cbaf-bca1-95e5" name="Tempest Hammer" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8532-e14b-13fd-91c2" targetId="ea4c-7569-acba-851f" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="e0f4-5be4-188d-6f8c" targetId="da4cc1e9-9855-01d0-f968-d551470dce58" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="bfdc-f5c5-672a-f356" name="Wolf Lord Krom, The Fierce Eye" points="150.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="f273-fc68-0348-0c92" name="Wyrmclaw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="aa3d-9636-18b6-a1dd" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Wyrmclaw" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+2"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Master-crafted, Unwieldy"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="fbb0-cc5b-774b-bec5" name="Duty or Death" hidden="false">
-          <description>Krom can re-roll all failed saving throws when he is within 3&quot; of an Objective Marker.</description>
-          <modifiers/>
-        </rule>
-        <rule id="39b5-3c6b-8034-6934" name="The Fierce-eye" hidden="false">
-          <description>Krom can re-roll failed To Wound rolls in close combat</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="1749-e185-75da-853a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Wolf Lord Krom, The Fierce Eye" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character) "/>
-            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
-            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
-            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
-            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
-            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
-            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
-            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
-            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="8984-f5df-66f3-a00f" targetId="74d72175-8c6f-57a0-56d0-bb498cb5e030" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="df7c-df9a-7631-5c58" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="61ea-f4d4-f358-23fc" targetId="e9cfe9f3-9259-1e61-7c53-9f6147e5bee9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="1b1d-af21-dfd0-da02" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="2892-5e27-5898-ce22" targetId="9ba00ec4-2c72-2463-c497-b706c5ab98f9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="e3e8-bcd5-4cbe-8074" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1bfd-8b8a-9f30-cc21" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6abd-b3ea-6c98-a518" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="274d-ed28-1bc9-b521" targetId="98d356a2-8d8b-af1a-4228-90d7d1e6d45a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6a0a-1e30-5a82-c1bf" targetId="cb0122dd-c2e2-3881-4e57-4840e8f3346c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="dca0-9ecd-b61f-b15a" name="Harald Deathwolf, Lord of the Wolfkin" points="190.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="50">
-      <entries>
-        <entry id="c03c-52f8-2980-d4c2" name="Frost Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="c91d-6117-d0f0-89e6" targetId="8a52ed78-8139-b06a-2f9e-c574962705b6" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="0306-6c94-2915-4444" name="Relic: Mantle of the Ice Troll King" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="97e4-a177-ad3d-621c" targetId="7f4045ec-808f-b7b5-9261-acce421cdf14" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b0ef-28bd-bba1-e7e8" targetId="dbca7f53-0ee4-9441-a689-02f0b2a1cc43" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="6809-1bee-a198-b9ce" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="07d2-67bd-973d-7586" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b29b-1733-9df5-69a7" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="64cb-cfbe-2b57-868c" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0ed7-3e4b-0cd3-be12" targetId="7ae778b2-8ebc-ffde-bdbe-cbfcb6675c9d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="618e-2d32-a634-6378" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8ddc-7d8c-5fe1-5919" targetId="233e6766-e598-f204-c36f-f400348f38dc" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1b05-4be4-f810-67cd" targetId="23c483d1-b5ec-5348-487f-befd40201037" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8c85-d342-45fc-0079" targetId="e9cfe9f3-9259-1e61-7c53-9f6147e5bee9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="96f6-d164-8de6-fd4d" targetId="791149d1-ea3f-3e5e-3390-f36857a6794d" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="5a35-1f54-a2b4-2a6e" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8299-30f0-fc24-6e97" targetId="d3fb2835-5b64-beb7-c844-df8ddc84a8ac" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="5b9f-4095-81ac-30df" targetId="5a2ea81e-b2dc-c9f1-b755-16fa94f7f90e" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="104c-080c-d7c4-fa8d" targetId="839e7904-8031-eb38-f7c8-c235b0b7a6bc" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
     </entry>
   </sharedEntries>
   <sharedEntryGroups>
@@ -44546,6 +44549,15 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       </characteristics>
       <modifiers/>
     </profile>
+    <profile id="ea4c-7569-acba-851f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Tempest Hammer" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="X2"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Helfrost, Specialist Weapon, Unwieldy"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
     <profile id="f386a667-ebb6-558b-86b0-bb8d36e3f6a5" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Tempest Warblade" hidden="false" book="40k Castigator.pdf" page="0">
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
@@ -45300,15 +45312,6 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
         <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
         <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2, Cluster Warhead, Terminal Tracking"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="ea4c-7569-acba-851f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Tempest Hammer" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
-        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="X2"/>
-        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
-        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Helfrost, Specialist Weapon, Unwieldy"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
- Fixed conditions for GH and made Transports mandatory for Ironwolves formation
  - Closes #1921 and #1924
- Modified Vehicle squadrons to allow adding models.
  - Closes #1927 
- Fixed default model count for units and default weapon choices
  - Closes #1929
