### PR TITLE
Fixed Retribution Phalanx

### DIFF
--- a/Necrons - Codex (2015).cat
+++ b/Necrons - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="026a-37f6-fa3a-c213" revision="11" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Necrons: Codex (2015)" books="Necrons: Codex (2015)" authorName="Kangodo, Tobias" authorContact="Report issues and bugs for this Codex here:" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="026a-37f6-fa3a-c213" revision="12" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Necrons: Codex (2015)" books="Necrons: Codex (2015)" authorName="Kangodo, Tobias" authorContact="Report issues and bugs for this Codex here:" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="c528a153-c346-46d9-a7e5-d5e0fd485ea5" name="Acquisition Phalanx" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="40k Apocalypse" page="169">
       <entries/>
@@ -4975,7 +4975,7 @@ If the Tomb Ziggurat is destroyed, the docked warmachine takes a S10, AP2 hit.</
           <entryGroups/>
           <modifiers/>
           <links>
-            <link id="f0fe-8494-7740-89e9" targetId="e3727ff3-fc7a-7ff3-d790-599ef232c46c" linkType="entry">
+            <link id="f0fe-8494-7740-89e9" targetId="44fc-1fd3-16d9-7f01" linkType="entry">
               <modifiers/>
             </link>
           </links>
@@ -6329,6 +6329,112 @@ If the Tomb Ziggurat is destroyed, the docked warmachine takes a S10, AP2 hit.</
       </rules>
       <profiles/>
       <links/>
+    </entry>
+    <entry id="44fc-1fd3-16d9-7f01" name="Triarch Stalker" points="125.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="bd8a-704a-ab4c-89b9" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="3d2c-e4d9-3390-31c1" name="Heat Ray" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="edbf-e79d-0176-701d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heat Ray (Focused Beam)" hidden="false" book="Codex: Necron" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2, Melta"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="fb84-7955-23c7-6864" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heat Ray (Dispersed Beam)" hidden="false" book="Codex: Necron" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="db75-38d2-d2bf-2d26" name="Particle Shredder" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="14dc-489e-e47e-cba4" targetId="1fdc-a26b-0669-d8d2" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7271-71d7-d7df-d83e" name="Twin-Linked Heavy Gauss Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="010e-1046-1a4d-b3ce" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Gauss Cannon" hidden="false" book="Codex: Necron" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Gauss"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="c17c-3c4f-1957-78ec" targetId="7fb8-acc7-166e-ddb5" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="61dc-f0e8-4f26-359a" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Triarch Stalker" hidden="false" book="Codex: Necron" page="0">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker, Open-topped)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="8811-4f34-29fd-45a7" targetId="461bbe4e-d707-b924-e36c-3506a4b46feb" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2b9b-ac45-968c-3b54" targetId="95614df6-20c6-e8da-09c8-2d0ec7c2f26b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="90c3-6904-3b95-69c8" targetId="afe575b9-affb-38e0-0fe7-022c2dca65a7" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ab0c-2571-877f-6eac" targetId="a29adba2-3913-9e6b-404f-e10f173c7f73" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
   </sharedEntries>
   <sharedEntryGroups>

--- a/Necrons - Codex (2015).cat
+++ b/Necrons - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="026a-37f6-fa3a-c213" revision="12" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Necrons: Codex (2015)" books="Necrons: Codex (2015)" authorName="Kangodo, Tobias" authorContact="Report issues and bugs for this Codex here:" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="026a-37f6-fa3a-c213" revision="13" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Necrons: Codex (2015)" books="Necrons: Codex (2015)" authorName="Kangodo, Tobias" authorContact="Report issues and bugs for this Codex here:" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="c528a153-c346-46d9-a7e5-d5e0fd485ea5" name="Acquisition Phalanx" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="40k Apocalypse" page="169">
       <entries/>
@@ -2054,7 +2054,7 @@ The removed units may Deep Strike back into the game and the first placed model 
       <profiles/>
       <links/>
     </entry>
-    <entry id="cd5287a0-b660-ba9a-4f15-62234bf0a303" name="Canoptek Spyders" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="cd5287a0-b660-ba9a-4f15-62234bf0a303" name="Canoptek Spyder" points="50.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="64ba2282-8f5b-5140-06c2-8ed0f7cba9f1" name="Canoptek Spyder" points="50.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
@@ -5946,6 +5946,112 @@ If the Tomb Ziggurat is destroyed, the docked warmachine takes a S10, AP2 hit.</
         </link>
       </links>
     </entry>
+    <entry id="44fc-1fd3-16d9-7f01" name="Triarch Stalker" points="125.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="bd8a-704a-ab4c-89b9" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="3d2c-e4d9-3390-31c1" name="Heat Ray" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="edbf-e79d-0176-701d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heat Ray (Focused Beam)" hidden="false" book="Codex: Necron" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2, Melta"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="fb84-7955-23c7-6864" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heat Ray (Dispersed Beam)" hidden="false" book="Codex: Necron" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="db75-38d2-d2bf-2d26" name="Particle Shredder" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="14dc-489e-e47e-cba4" targetId="1fdc-a26b-0669-d8d2" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7271-71d7-d7df-d83e" name="Twin-Linked Heavy Gauss Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="010e-1046-1a4d-b3ce" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Gauss Cannon" hidden="false" book="Codex: Necron" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Gauss"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="c17c-3c4f-1957-78ec" targetId="7fb8-acc7-166e-ddb5" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="61dc-f0e8-4f26-359a" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Triarch Stalker" hidden="false" book="Codex: Necron" page="0">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker, Open-topped)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="8811-4f34-29fd-45a7" targetId="461bbe4e-d707-b924-e36c-3506a4b46feb" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2b9b-ac45-968c-3b54" targetId="95614df6-20c6-e8da-09c8-2d0ec7c2f26b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="90c3-6904-3b95-69c8" targetId="afe575b9-affb-38e0-0fe7-022c2dca65a7" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ab0c-2571-877f-6eac" targetId="a29adba2-3913-9e6b-404f-e10f173c7f73" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="e3727ff3-fc7a-7ff3-d790-599ef232c46c" name="Triarch Stalkers" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="d8e4-6f6c-2ee5-8125" name="Triarch Stalker" points="125.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -6330,111 +6436,88 @@ If the Tomb Ziggurat is destroyed, the docked warmachine takes a S10, AP2 hit.</
       <profiles/>
       <links/>
     </entry>
-    <entry id="44fc-1fd3-16d9-7f01" name="Triarch Stalker" points="125.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="bd8a-704a-ab4c-89b9" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entry id="c4e9-462e-b6bf-a920" name="Canoptek Spyders" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="5c09-7ede-8654-e44e" name="Canoptek Spyder" points="50.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="3d2c-e4d9-3390-31c1" name="Heat Ray" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles>
-                <profile id="edbf-e79d-0176-701d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heat Ray (Focused Beam)" hidden="false" book="Codex: Necron" page="0">
-                  <characteristics>
-                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
-                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
-                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
-                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2, Melta"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-                <profile id="fb84-7955-23c7-6864" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heat Ray (Dispersed Beam)" hidden="false" book="Codex: Necron" page="0">
-                  <characteristics>
-                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
-                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
-                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
-                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-              </profiles>
-              <links/>
-            </entry>
-            <entry id="db75-38d2-d2bf-2d26" name="Particle Shredder" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="091c-344a-c4ce-5992" name="Fabricator Claw Array" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="14dc-489e-e47e-cba4" targetId="1fdc-a26b-0669-d8d2" linkType="profile">
+                <link id="fe84-6e07-9e6b-6e7a" targetId="087d513f-5101-a43a-9861-fecfd2a7b27d" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
             </entry>
-            <entry id="7271-71d7-d7df-d83e" name="Twin-Linked Heavy Gauss Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="c53c-15c8-3e72-de59" name="Gloom Prism" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="563e-b4f3-c89e-21da" targetId="fc91d402-9762-8298-406b-44bddad161fa" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="ce90-1cea-a0a8-16d7" name="Twin-Linked Particle Beamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles>
-                <profile id="010e-1046-1a4d-b3ce" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Gauss Cannon" hidden="false" book="Codex: Necron" page="0">
+                <profile id="839d-378e-d34d-039e" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Twin-Linked Particle Beamer" hidden="false" book="Codex: Necron" page="0">
                   <characteristics>
-                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
-                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
-                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
-                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Gauss"/>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Blast"/>
                   </characteristics>
                   <modifiers/>
                 </profile>
               </profiles>
-              <links>
-                <link id="c17c-3c4f-1957-78ec" targetId="7fb8-acc7-166e-ddb5" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
+              <links/>
             </entry>
           </entries>
           <entryGroups/>
           <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
+          <rules/>
+          <profiles>
+            <profile id="128a-4243-998a-f499" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Canoptek Spyder" hidden="false" book="Codex: Necron" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="504a-2b41-fd43-8c49" targetId="faad5d37-879f-f813-f34d-6ff73872b277" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="ac5a-59be-9b63-007c" targetId="e583afe1-a06e-e3dd-3640-ee9fdfabbb4a" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
       <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="61dc-f0e8-4f26-359a" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Triarch Stalker" hidden="false" book="Codex: Necron" page="0">
-          <characteristics>
-            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
-            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
-            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
-            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
-            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
-            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
-            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
-            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
-            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
-            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker, Open-topped)"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="8811-4f34-29fd-45a7" targetId="461bbe4e-d707-b924-e36c-3506a4b46feb" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2b9b-ac45-968c-3b54" targetId="95614df6-20c6-e8da-09c8-2d0ec7c2f26b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="90c3-6904-3b95-69c8" targetId="afe575b9-affb-38e0-0fe7-022c2dca65a7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ab0c-2571-877f-6eac" targetId="a29adba2-3913-9e6b-404f-e10f173c7f73" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
+      <profiles/>
+      <links/>
     </entry>
   </sharedEntries>
   <sharedEntryGroups>


### PR DESCRIPTION
Set Triarch Stalker to 1 max until a GW FAQ comes out.  Datasheet specifically says 1 Triarch Stalker, not 1 Unit - compared to it saying 1 Unit of Warriors and not 1 Warrior
