### PR TITLE
Blackmane Formation Fixes

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="59" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="60" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
@@ -23652,7 +23652,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="d705899a-961e-4230-8829-23ef49301432" name="Lone Wolf" points="20.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="0" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="65">
+    <entry id="d705899a-961e-4230-8829-23ef49301432" name="Lone Wolf" points="20.0" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="65">
       <entries/>
       <entryGroups>
         <entryGroup id="6d397d9e-45fb-45b8-8f92-c8e611307525" name="Armour" defaultEntryId="cf9bbbc8-a186-4481-874a-89f48d6a3cb1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -27022,7 +27022,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="70dc-762e-d2d7-c728" name="0-1 Veterans" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="70dc-762e-d2d7-c728" name="1 Veterans" defaultEntryId="ba8a-c91a-5fcf-0607" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -27087,7 +27087,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="aaa3-650d-f740-07c7" name="0-1 Wolf Scouts" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="aaa3-650d-f740-07c7" name="1 Wolf Scouts" defaultEntryId="02e9-cbe8-d5d9-5fb7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>


### PR DESCRIPTION
Fixed Lone Wolf issue and made Veterans/Scouts required instead of
optional to match supplement.  Closes #1970
