### PR TITLE
Fixes for The Ironwolves and Ancients of the Fang

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="60" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="61" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
@@ -17059,7 +17059,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
     <link id="63a8-a365-2b6c-1e08" targetId="d466-2fd4-e70c-3a24" linkType="entry" categoryId="9050-d437-3301-7e42">
       <modifiers/>
     </link>
-    <link id="36d9-f562-30e5-1dd8" targetId="5792-fe80-e088-1144" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+    <link id="36d9-f562-30e5-1dd8" targetId="5792-fe80-e088-1144" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
       <modifiers/>
     </link>
     <link id="765d-ecac-2bcd-275e" targetId="8cef-dfed-4131-a054" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
@@ -19544,7 +19544,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="5792-fe80-e088-1144" name="Ancients of the Fang" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="20">
+    <entry id="5792-fe80-e088-1144" name="Ancients of the Fang" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="47">
       <entries/>
       <entryGroups>
         <entryGroup id="e112-18fe-e574-2789" name="2-5 Dreadnoughts" defaultEntryId="0f41-bff6-ee9d-ac6a" minSelections="2" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -19565,13 +19565,26 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             <link id="c335-f6b1-8b53-64e8" targetId="eab714a3-18ea-822a-f117-be2f452edaae" linkType="entry">
               <modifiers/>
             </link>
+            <link id="572a-f9f9-afc2-ec63" targetId="5b96-9766-6096-d837" linkType="entry">
+              <modifiers/>
+            </link>
           </links>
         </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules/>
       <profiles/>
-      <links/>
+      <links>
+        <link id="eef8-74c1-22ae-8737" targetId="c497-8813-3ae2-7e77" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3584-a53e-379e-895e" targetId="0293-590a-29b9-d274" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="42b3-5e68-3e8c-55c6" targetId="0518-77dc-a444-9c9e" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="dc78e902-c9df-3044-3812-9458bf620d8a" name="Arjac Rockfist" points="115.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="70">
       <entries>
@@ -22336,6 +22349,18 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             </link>
           </links>
         </entry>
+        <entry id="66ce-917f-6e60-17ee" name="Thunder Hammer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="90d5-f864-1433-ba1d" targetId="85d2dada-b527-d574-f923-56ea9f013e6d" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
       </entries>
       <entryGroups>
         <entryGroup id="cc9f-b350-0aa7-e935" name="Mount" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -22464,9 +22489,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </link>
         <link id="0320-59b5-b73a-625a" targetId="65e2ebff-7328-b852-21a9-9a1c5f48cbbd" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="d298-cdf9-6bdf-7126" targetId="d791dd4c-fba5-7cb5-cee6-3dfbea870a14" linkType="entry">
           <modifiers/>
         </link>
       </links>
@@ -27794,7 +27816,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups/>
-                      <modifiers/>
+                      <modifiers>
+                        <modifier type="increment" field="points" value="7.0" repeat="true" numRepeats="1" incrementParentId="facf-039b-4cbe-369b" incrementChildId="3ffd-fbd1-161e-d437" incrementField="selections" incrementValue="1.0">
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
                       <rules/>
                       <profiles/>
                       <links>
@@ -27809,7 +27836,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     <entry id="52ef-7b83-f6e7-066a" name="Jump Packs" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                       <entries/>
                       <entryGroups/>
-                      <modifiers/>
+                      <modifiers>
+                        <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="facf-039b-4cbe-369b" incrementChildId="3ffd-fbd1-161e-d437" incrementField="selections" incrementValue="1.0">
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
                       <rules/>
                       <profiles/>
                       <links>
@@ -39667,7 +39699,7 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
       <modifiers/>
       <links/>
     </entryGroup>
-    <entryGroup id="6a3111ba-8e57-5479-6d7a-482cb38b6bb4" name="Weapons wgbl" defaultEntryId="563be4b5-3a48-4504-ec6c-2604cc9c69a2" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entryGroup id="6a3111ba-8e57-5479-6d7a-482cb38b6bb4" name="Weapons wgbl" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="e31c4370-43ae-bb8a-5dd4-4aa96c6b4807" name="Plasma Pistol" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -42380,6 +42412,18 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       <modifiers/>
     </rule>
     <rule id="a703466f-57e0-dc75-5ad4-bdd4a4e132e0" name="Wyrdbane" hidden="false" book="Codex: Space Wolves" page="53">
+      <modifiers/>
+    </rule>
+    <rule id="c497-8813-3ae2-7e77" name="A Gathering of Ancients" hidden="false" book="Curse of the Wulfen" page="47">
+      <description>All of the Dreadnoughts from the Ancients of the Fang must be fielded as a single Vehicle Squadron as described in the Warhammer 40K rulebook. However, whilst this formation includes three or more Dreadnoughts, they can all re-roll failed To Hit rolls in close combat.</description>
+      <modifiers/>
+    </rule>
+    <rule id="0293-590a-29b9-d274" name="Blessings of the Iron Wolf" hidden="false" book="Curse of the Wulfen" page="47">
+      <description>Dreadnoughts from the Ancients of the Fang have the It Will Not Die special rule whilst they are within 6&quot; of their Iron Priest.</description>
+      <modifiers/>
+    </rule>
+    <rule id="0518-77dc-a444-9c9e" name="The Saga that Walks" hidden="false" book="Curse of the Wulfen" page="47">
+      <description>Friendly units with the Space Wolves faction within 6&quot; of a Dreadnought from the Ancients of the Fang have the Stubborn special rule.</description>
       <modifiers/>
     </rule>
   </sharedRules>


### PR DESCRIPTION
Closes #1966
- Ancients of the Fang entry fixed, is now a formation and has the rules
  for it
- Added option to choose old Iron Priest to Ancients of the Fang
- Fixed old Iron Priest Thunder Hammer weapon, as it was no longer
  appearing, since the last modification of the TH entry (modification was
  required because of new IP)
- Fixed point cost for Bikes/Jump packs option for WG in The Ironwolves
- Removed default selection of Chainsword for WGBL because it was causing a UI glitch and it was wrong for WGBL to have 2 chainswords in the first place
