### PR TITLE
Space Wolves - Rules updates and Formation fixes

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="61" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="62" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
@@ -17053,9 +17053,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
     <link id="6132-b362-421c-f917" targetId="d705899a-961e-4230-8829-23ef49301432" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
       <modifiers/>
     </link>
-    <link id="81f9-a338-b108-cef6" targetId="e5e9e3ff-a78b-721c-7ec9-f92745577bc0" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
-      <modifiers/>
-    </link>
     <link id="63a8-a365-2b6c-1e08" targetId="d466-2fd4-e70c-3a24" linkType="entry" categoryId="9050-d437-3301-7e42">
       <modifiers/>
     </link>
@@ -17150,6 +17147,32 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <modifiers/>
     </link>
     <link id="1c15-254d-b102-5698" targetId="5b96-9766-6096-d837" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
+      <modifiers/>
+    </link>
+    <link id="0aa5-d6bd-4952-e3e9" targetId="5792-fe80-e088-1144" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="a032-435d-b2d8-d986" targetId="8813-a4a2-87e6-3b6f" linkType="rule">
+      <modifiers>
+        <modifier type="show" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="force type" childId="3c6f-d590-738a-c264" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+    </link>
+    <link id="e0ff-c2ca-5f5b-35a4" targetId="f02c-52ec-cde2-14bb" linkType="rule">
+      <modifiers>
+        <modifier type="show" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="force type" childId="3c6f-d590-738a-c264" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+    </link>
+    <link id="7633-4abc-1149-c1e3" targetId="da70-8847-b78e-2abc" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
       <modifiers/>
     </link>
   </links>
@@ -18648,7 +18671,18 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="dffc-27eb-0caa-f56b" name="Stormfang Gunship" defaultEntryId="0849-ddb8-b938-3008" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="0849-ddb8-b938-3008" targetId="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInRoster" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
@@ -18673,9 +18707,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </link>
         <link id="56163067-049d-a55e-229d-09618632f625" targetId="aa9270d8-c94a-1b2c-4cce-532a57653e93" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="aa7de9f3-e51b-63df-5549-bd6d58ad7878" targetId="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" linkType="entry">
           <modifiers/>
         </link>
         <link id="ae86f846-1391-7d1c-0ebb-9c6c334ba4a2" targetId="328d4778-7dd9-664b-9c44-edb137fd0939" linkType="rule">
@@ -21086,20 +21117,27 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="3248-ba18-e824-853d" name="Fangs of the tempest" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entry id="3248-ba18-e824-853d" name="Fangs of the Tempest" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="31">
       <entries/>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="c727-8f37-cc9f-3603" name="1 Battleship" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="9505-2a07-964e-e809" targetId="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7043-53f6-c145-a14f" targetId="5352e828-66c4-837a-3d88-606e87be25f2" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles/>
-      <links>
-        <link id="5366-5cfb-951c-8aa9" targetId="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="e87d-a421-c532-c470" targetId="5352e828-66c4-837a-3d88-606e87be25f2" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
+      <links/>
     </entry>
     <entry id="85f8e5db-5e5f-32a7-58e6-25006d5c1cb5" name="Fellblade Super-Heavy Tank (FW)" points="540.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour II 2nd Ed" page="105">
       <entries>
@@ -21349,7 +21387,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="3bdb-0a80-f398-f241" name="Greatpack" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen">
+    <entry id="3bdb-0a80-f398-f241" name="Greatpack" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="42">
       <entries/>
       <entryGroups>
         <entryGroup id="37dd-42d5-4849-1e99" name="Commander" defaultEntryId="6e0f-3eec-7450-7276" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -21465,12 +21503,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="09a4-a920-5064-8a7d" name="Jarl of Russ" hidden="false" book="Curse of the Wulfen">
+        <rule id="09a4-a920-5064-8a7d" name="Jarl of Russ" hidden="false" book="Curse of the Wulfen" page="42">
+          <description>If this Formation is your Primary Detachment, or is part of your Primary Detachment, you can re-roll the result when rolling on the Warlord Traits table in Codex: Space Wolves</description>
           <modifiers/>
         </rule>
-        <rule id="8a19-2b82-5dd7-9331" name="Cunning of the Wolf" hidden="false" book="Curse of the Wulfen">
-          <description>
-</description>
+        <rule id="8a19-2b82-5dd7-9331" name="Cunning of the Wolf" hidden="false" book="Curse of the Wulfen" page="42">
+          <description>Before deployment, roll a D6 for each unit in a Greatpack, adding 2 to the result if the unit&apos;s Battlefield Role is Troops and it has been joined by an Independent Characterfrom this Formation (before rolling, inform your opponent which Independent Characters, if any, will start the game joined to which Troops units). On a 6+, that unit has the Outflank special rule. In addition, if a Greatpack is lead by a Wolf Lord, at the start of each of your turns after the first, you may select one unit from this Formation that is in Reserves. That unit automatically passes its Reserve Roll to arrive this turn (no dice roll is necessary).</description>
           <modifiers/>
         </rule>
       </rules>
@@ -22062,7 +22100,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="1aa4-8384-76ba-cabd" name="Heralds of the Great Wolf" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="21">
+    <entry id="1aa4-8384-76ba-cabd" name="Heralds of the Great Wolf" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="48">
       <entries/>
       <entryGroups>
         <entryGroup id="0b69-1f55-993d-01c4" name="Iron Priest" defaultEntryId="b5c9-232b-0e2b-fe24" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -22071,6 +22109,9 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
           <links>
             <link id="b5c9-232b-0e2b-fe24" targetId="eab714a3-18ea-822a-f117-be2f452edaae" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="1ef1-41ab-53d5-fe97" targetId="5b96-9766-6096-d837" linkType="entry">
               <modifiers/>
             </link>
           </links>
@@ -22103,7 +22144,19 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules/>
+      <rules>
+        <rule id="14dc-9a96-9315-4512" name="Brotherhood of Priests" hidden="false" book="Curse of the Wulfen" page="48">
+          <description>The Heralds of the Great Wolf must be deployed as a single unit. In addition, all models in the Formation lose the Independent Character special rule, but gain the following special rules and benefits whilst the relevant model from this Formation is still alive:
+- Wolf Priest: It Will Not Die
+- Rune Priest: Enemy units that target the Heralds of the Great Wolf in the Shooting phase must subtract 1 from their Ballistic Skill characteristic.
+- Iron Priest: Ignore the first failed saving throw made by a Herald of the Great Wolf each phase.</description>
+          <modifiers/>
+        </rule>
+        <rule id="d856-7ce1-3ef5-d728" name="Sage Counsel" hidden="false" book="Curse of the Wulfen" page="48">
+          <description>An army that includes any Heralds of the Great Wolf can re-roll the dice when determining who deploys first, and adds 1 to the dice roll when attempting to Seize the Initiative.</description>
+          <modifiers/>
+        </rule>
+      </rules>
       <profiles/>
       <links/>
     </entry>
@@ -23364,32 +23417,39 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <profiles/>
       <links/>
     </entry>
-    <entry id="28f0-1643-b945-efb1" name="Legendary Greatpack" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entry id="28f0-1643-b945-efb1" name="Legendary Greatpack" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="36-41">
       <entries/>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="17fc-2dc6-d310-cd8c" name="Legendary Greatpack" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="84ae-0df6-f077-622c" targetId="b465-8f76-111c-4aa2" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="4a54-05ce-0ea4-18d7" targetId="2c8d-4517-ed3b-8133" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="3844-a033-71ad-03b8" targetId="2890-44a3-a6e2-cddd" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="cb77-895f-a70f-61ed" targetId="e4b5-7cd3-566c-81ce" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="be23-2dc1-3d3a-2244" targetId="c803-fdf8-a5f4-55c5" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="19f1-7683-8b12-03f7" targetId="3d76-879c-3cea-3b2f" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles/>
-      <links>
-        <link id="a758-3975-df7e-5a64" targetId="b465-8f76-111c-4aa2" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8707-ce57-1b9b-f3ca" targetId="c803-fdf8-a5f4-55c5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="fdf3-e11f-9038-1dbd" targetId="3d76-879c-3cea-3b2f" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4922-208f-3cbe-2523" targetId="2c8d-4517-ed3b-8133" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="bdd3-9e61-59bc-8f14" targetId="e4b5-7cd3-566c-81ce" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="ed6a-d03a-ed20-6ad0" targetId="2890-44a3-a6e2-cddd" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
+      <links/>
     </entry>
     <entry id="394edb22-791d-a041-0587-20629741333b" name="Locator Beacon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
@@ -24452,10 +24512,10 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="d466-2fd4-e70c-3a24" name="Lord of the Fang" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entry id="d466-2fd4-e70c-3a24" name="Lord of the Fang" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="31">
       <entries/>
       <entryGroups>
-        <entryGroup id="4a12-14e7-998d-cbe3" name="Lord of the Fang" defaultEntryId="b17d-202b-4eee-21b1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="4a12-14e7-998d-cbe3" name="Lord of the Fang" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -26433,7 +26493,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="d371-b7fd-89b8-5a87" name="Spear of Russ" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="18">
+    <entry id="d371-b7fd-89b8-5a87" name="Spear of Russ" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="44">
       <entries/>
       <entryGroups>
         <entryGroup id="b5bb-44d3-3722-60a2" name="1-3 Iron Priests" defaultEntryId="e84b-e672-e920-4dff" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -26480,7 +26540,16 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules/>
+      <rules>
+        <rule id="c574-839f-4977-7a33" name="Alpha Machine Spirits" hidden="false" book="Curse of the Wulfen" page="44">
+          <description>Vehicles from a Spear of Russ have the Power of the Machine Spirit special rule whilst they are within 12&quot; of any Land Raiders, Land Raider Crusaders or Land Raider Redeemers from the same Formation.</description>
+          <modifiers/>
+        </rule>
+        <rule id="3216-05b4-6914-c16d" name="Lord of Iron" hidden="false" book="Curse of the Wulfen" page="44">
+          <description>At the start of each of your Shooting phases, nominate one vehicle from a Spear of Russ that is either transporting, or is within 6&quot; of, any Iron Priests from the same Formation. That vehicle gains a special rule from the following list for that phase: Monster Hunter, Precision Shots, Preferred Enemy, Tank Hunters.</description>
+          <modifiers/>
+        </rule>
+      </rules>
       <profiles/>
       <links/>
     </entry>
@@ -26508,7 +26577,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" name="Stormfang Gunship" points="220.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="80">
+    <entry id="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" name="Stormfang Gunship" points="220.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="80">
       <entries>
         <entry id="12223997-6749-6eac-29ce-c342aa6ce7cb" name="Helfrost Destructor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -27132,15 +27201,15 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="99d3-413e-4eed-4d73" name="The Claws of Russ" hidden="false" book="Curse of the Wulfen">
+        <rule id="99d3-413e-4eed-4d73" name="The Claws of Russ" hidden="false" book="Curse of the Wulfen" page="40">
           <description>Any Blackmanes unit that has the option to take a Drop Pod as a Dedicated Transport may take one at no points cost (though they must pay for any additional upgrades and options as normal). All Drop Pods in this Formation arrive from Deep Strike Reserve at the start of the controlling player&apos;s first turn. Drop Pods in this Formation do not count towards the number of models that arrive in the first turn as part of the Drop Pod Assault special rule.</description>
           <modifiers/>
         </rule>
-        <rule id="2575-fe5f-4933-06fb" name="Inspirational Example" hidden="false" book="Curse of the Wulfen">
-          <description>Whilst Ragnar Blackmane is on the battlefield, he and all units of Blood Claws, Sky Claws and Swiftclaws from this Formation re-roll all failed To Hit rolls in close combat.</description>
+        <rule id="2575-fe5f-4933-06fb" name="Inspirational Example" hidden="false" book="Curse of the Wulfen" page="40">
+          <description>Whilst Ragnar Blackmane is on the battlefield, he and all units of Blood Claws, Skyclaws and Swiftclaws from this Formation re-roll all failed To Hit rolls in close combat.</description>
           <modifiers/>
         </rule>
-        <rule id="c63c-25be-9d95-adff" name="The Joy of Battle" hidden="false" book="Curse of the Wuflen">
+        <rule id="c63c-25be-9d95-adff" name="The Joy of Battle" hidden="false" book="Curse of the Wuflen" page="40">
           <description>Blackmanes units that disembark from a Drop Pod have the Fearless and Feel No Pain (6+) special rules until the start of their next turn.</description>
           <modifiers/>
         </rule>
@@ -27254,7 +27323,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <rules/>
       <profiles/>
       <links>
-        <link id="b9ea-c04b-2a54-9042" targetId="a28a16cc-c39e-0905-c7d5-449dafc2c556" linkType="rule">
+        <link id="b9ea-c04b-2a54-9042" targetId="597f-6d8d-e61c-414a" linkType="rule">
           <modifiers/>
         </link>
         <link id="3bce-54ab-d417-e2d5" targetId="06f450df-e80c-eb11-efe2-3808f6891556" linkType="rule">
@@ -27373,10 +27442,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="f59b-09c0-fc39-152a" name="Peerless Hunters" hidden="false" book="Curse of the Wulfen">
+        <rule id="f59b-09c0-fc39-152a" name="Peerless Hunters" hidden="false" book="Curse of the Wulfen" page="39">
+          <description>When making Reserve Rolls, make a single roll for all Outflanking Deathwolves units, which you can choose to re-roll. On a successful Reserves Roll, all of the Outflanking Deathwolves units arrive from Reserve. In addition, Outflanking Deathwolves units have the Stealth special rule on the turn they arrive from Reserve.</description>
           <modifiers/>
         </rule>
-        <rule id="75ac-8d87-6586-e4ce" name="Run to Ground" hidden="false">
+        <rule id="75ac-8d87-6586-e4ce" name="Run to Ground" hidden="false" book="Curse of the Wulfen" page="39">
+          <description>When making Sweeping Advance rolls for a Deathwolves unit, roll 2 dice and pick the highest.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -27478,10 +27549,12 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="a0d3-d946-b614-a781" name="Glory Seekers" hidden="false" book="Curse of the Wulfen">
+        <rule id="a0d3-d946-b614-a781" name="Glory Seekers" hidden="false" book="Curse of the Wulfen" page="38">
+          <description>Characters from this Formation have the Preferred Enemy (Characters) special rule. In addition, if one friendly unit from this Formation makes a successful charge, all other Drakeslayer units can re-roll failed charge rolls for the rest of the phase.</description>
           <modifiers/>
         </rule>
-        <rule id="64b2-0f39-984c-4971" name="Furious Determination" hidden="false" book="Curse of the Wulfen">
+        <rule id="64b2-0f39-984c-4971" name="Furious Determination" hidden="false" book="Curse of the Wulfen" page="38">
+          <description>Whilst Wolf Lord Krom is on the batlefield, all Drakeslayer models have the Furious Charge special rule.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -27717,13 +27790,16 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="ec7f-3211-d5e6-8ac3" name="Eager for Combat" hidden="false" book="Curse of the Wulfen">
+        <rule id="ec7f-3211-d5e6-8ac3" name="Eager for Combat" hidden="false" book="Curse of the Wulfen" page="36">
+          <description>All Firehowlers units can re-roll failed charge rolls.</description>
           <modifiers/>
         </rule>
-        <rule id="41f3-3ad9-5a4f-ed35" name="Bloodcurdling Charge" hidden="false" book="Curse of the Wulfen">
+        <rule id="41f3-3ad9-5a4f-ed35" name="Bloodcurdling Charge" hidden="false" book="Curse of the Wulfen" page="36">
+          <description>Enemy units attempting to fire Overwatch at a charging Firehowlers unit must first pass a Leadership test or be unableto fire Overwatch for the duration of that Assault phase. In addition, units from this formation cause Fear on the turn they charge. Enemy units with the And They Shall Know No Fear or Fearless special rules are immune to the effects of Bloodcurdling Charge.</description>
           <modifiers/>
         </rule>
-        <rule id="2bd2-3404-9968-76be" name="Rising Fury" hidden="false">
+        <rule id="2bd2-3404-9968-76be" name="Rising Fury" hidden="false" book="Curse of the Wulfen" page="36">
+          <description>If you roll a 10 or more when determining the charge distance of a Firehowlers unit, all models in that unit have the Furious Charge special rule that turn.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -32165,7 +32241,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </rule>
         <rule id="2787-daa5-ed96-e021" name="Validation for ironwolves" hidden="false">
-          <description>Validation for ironwolves dedicated transport restrictions is not working, this will be available in 1.16 but please ensure you leave enough spaces in your transports for all non vehicle models.</description>
+          <description>Validation for ironwolves dedicated transport restrictions is not working, this will be available in 1.16 but, for now, please ensure that you leave enough spaces in your transports for all non vehicle models from this formation.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -32626,7 +32702,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="fa230f5b-ee25-91a6-5bdb-4c50f298b47b" name="Ulrik the Slayer, Wolf High Priest" points="145.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="55">
+    <entry id="fa230f5b-ee25-91a6-5bdb-4c50f298b47b" name="Ulrik the Slayer, Wolf High Priest" points="145.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="55">
       <entries>
         <entry id="8d5ec83f-f56d-7568-a78b-a975d064728d" name="Relic: Wolf Helm of Russ" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -34319,7 +34395,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
     </entry>
     <entry id="bfdc-f5c5-672a-f356" name="Wolf Lord Krom, The Fierce Eye" points="150.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
-        <entry id="f273-fc68-0348-0c92" name="Wyrmclaw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entry id="f273-fc68-0348-0c92" name="Wyrmclaw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -34341,17 +34417,17 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <entryGroups/>
       <modifiers/>
       <rules>
-        <rule id="fbb0-cc5b-774b-bec5" name="Duty or Death" hidden="false">
+        <rule id="fbb0-cc5b-774b-bec5" name="Duty or Death" hidden="false" book="Curse of the Wulfen" page="32">
           <description>Krom can re-roll all failed saving throws when he is within 3&quot; of an Objective Marker.</description>
           <modifiers/>
         </rule>
-        <rule id="39b5-3c6b-8034-6934" name="The Fierce-eye" hidden="false">
-          <description>Krom can re-roll failed To Wound rolls in close combat</description>
+        <rule id="39b5-3c6b-8034-6934" name="The Fierce-eye" hidden="false" book="Curse of the Wulfen" page="32">
+          <description>Krom can re-roll failed To Wound rolls in close combat.</description>
           <modifiers/>
         </rule>
       </rules>
       <profiles>
-        <profile id="1749-e185-75da-853a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Wolf Lord Krom, The Fierce Eye" hidden="false">
+        <profile id="1749-e185-75da-853a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Wolf Lord Krom, The Fierce Eye" hidden="false" book="Curse of the Wulfen" page="32">
           <characteristics>
             <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character) "/>
             <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
@@ -35106,7 +35182,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
-    <entry id="8cef-dfed-4131-a054" name="Wolfkin" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="22">
+    <entry id="8cef-dfed-4131-a054" name="Wolfkin" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="49">
       <entries/>
       <entryGroups>
         <entryGroup id="a472-9980-a50e-03c4" name="Fenrisian Wolves" defaultEntryId="330c-0366-7452-8558" minSelections="2" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -35121,9 +35197,25 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules/>
+      <rules>
+        <rule id="cfe6-2212-a894-cec2" name="Alpha Pack" hidden="false" book="Curse of the Wulfen" page="49">
+          <description>If you wish, all of the units in a Wolfkin can be deployed as a single unit known as an Alpha Pack. Add 1 to the Attacks characteristic of All Fenrisian Wolf and Cyberwolf models in an Alpha Pack whilst there are 20 or more models in the unit.</description>
+          <modifiers/>
+        </rule>
+        <rule id="1da3-7923-98be-8ccd" name="Call of the Wolves" hidden="false" book="Curse of the Wulfen" page="49">
+          <description>If a Wolfkin unit is within 12&quot; of either the left or the right table edges, it can call forth nearby Space Wolves. You can choose to bring any friendly Outflanking Space Wolves units onto the battlefield from the table edge nearest to that Wolfkin unit instead of rolling to see which table edge they arrive from.</description>
+          <modifiers/>
+        </rule>
+      </rules>
       <profiles/>
-      <links/>
+      <links>
+        <link id="9ae4-0f66-db37-ddf9" targetId="be032c0b-31b0-03c7-8684-a4b645951889" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="fbc3-4fdb-6915-02c8" targetId="7ae778b2-8ebc-ffde-bdbe-cbfcb6675c9d" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
     </entry>
     <entry id="b39d-6620-f7b8-b856" name="Wulfen" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="64">
       <entries/>
@@ -35137,20 +35229,13 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <entryGroups/>
                   <modifiers/>
                   <rules>
-                    <rule id="b870-ba9a-952e-709b" name="Stormfrag Auto-Launcher" hidden="false">
-                      <description>STORMFRAG AUTO-LAUNCHER
-Mounted between the broad shoulders of the Wulfen, these compact grenade launchers are fed from drum units and guided by crude and belligerent targeting spirits. Their primary role is suppression, the launchers hammering out automated patterns of explosive charges as the Wulfen charge headlong into combat. The combination is a potent one; those foes not blown apart by the thumping explosion of the auto-launchers’ grenades are left reeling, and are swiftly torn apart by the Wulfen themselves.
-
-SHOOTING
-(profile included)
-
-ASSAULT
-Models in a unit that includes one or more models equipped with stormfrag auto-launchers do not suffer the penalty to their Initiative for charging enemies through difficult terrain, but fight at their normal Initiative in the ensuing combat.</description>
+                    <rule id="b870-ba9a-952e-709b" name="Stormfrag Auto-Launcher" hidden="false" book="Curse of the Wulfen" page="53">
+                      <description>Models in a unit that includes one or more models equipped with stormfrag auto-launchers do not suffer the penalty to their Initiative for charging enemies through difficult terrain, but fight at their normal Initiative in the ensuing combat.</description>
                       <modifiers/>
                     </rule>
                   </rules>
                   <profiles>
-                    <profile id="6ef4-4619-745f-b199" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Stormfrag Auto-Launcher" hidden="false">
+                    <profile id="6ef4-4619-745f-b199" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Stormfrag Auto-Launcher" hidden="false" book="Curse of the Wulfen" page="53">
                       <characteristics>
                         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12"/>
                         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
@@ -35209,6 +35294,9 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
                       <profiles/>
                       <links>
                         <link id="e625-1ca1-26d3-33c9" targetId="cd82-e243-6e8d-dc15" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="5b97-f339-21d4-fe97" targetId="e347-4382-5902-74e6" linkType="rule">
                           <modifiers/>
                         </link>
                       </links>
@@ -35271,13 +35359,37 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
       </entryGroups>
       <modifiers/>
       <rules>
-        <rule id="ff1b-739d-cf07-f74b" name="Death Frenzy" hidden="false" book="Curse of the Wulfen">
+        <rule id="ff1b-739d-cf07-f74b" name="Death Frenzy" hidden="false" book="Curse of the Wulfen" page="35">
+          <description>If a model in this unit is slain in the Fight sub-phase, it can, at the end of the current Initiative step, pile in and fight before being removed as a casualty. The model can do this even if it has already fought this phase.</description>
           <modifiers/>
         </rule>
-        <rule id="e2e4-e4c0-d517-97c7" name="Curse of the Wulfen" hidden="false" book="Curse of the Wulfen">
+        <rule id="e2e4-e4c0-d517-97c7" name="Curse of the Wulfen" hidden="false" book="Curse of the Wulfen" page="52">
+          <description>All non-vehicle Space Wolves units within 6&quot; of any units of Wulfen are affected by the Curse of the Wulfen. Blood Claws, Skyclaws and Swiftclaws are affected if within 12&quot; and Long Fangs if within 3&quot; of any unit of Wulfen. The Wulfen themselves, any units of Fenrisian Wolves or Servitors, as well as units that are embarked at the start of the turn, are not affected by the Curse of the Wulfen.
+At the start of your turn (after rolling for Reserves), roll one dice for all affected units and consult the relevant table below. Units that are not locked in combat are affected by the appropriate result on the Hunt table, whilst units that are locked in combat are affected by the appropriate result on the Kill table. These effects last until the start of your next turn.</description>
           <modifiers/>
         </rule>
-        <rule id="9fa8-2a54-0ae5-e71f" name="Bounding Lope" hidden="false" book="Curse of the Wulfen">
+        <rule id="9fa8-2a54-0ae5-e71f" name="Bounding Lope" hidden="false" book="Curse of the Wulfen" page="35">
+          <description>This unit can Run and charge in the same turn, and can re-roll failed charge rolls.</description>
+          <modifiers/>
+        </rule>
+        <rule id="5a1a-6801-a218-8c1b" name="Curse of the Wulfen - Hunt table" hidden="false" book="Curse of the Wulfen" page="52">
+          <description>(See Curse of the Wulfen special rule to determine affected units)
+1-3: Predatory Pounce
+Affected units have the Hammer of Wrath special rule and can re-roll failed charge rolls.
+4-5: Bestial Swiftness
+Add 3&quot; to the movement distances of all models in affected units when they move in the Movement phase, when they Run and when they make charge moves.
+6: Reckless Ferocity
+Models in affected units have the Furious Charge special rule and gain D3 bonus Attacks for charging instead of 1 (unless they already have the Rage special rule).</description>
+          <modifiers/>
+        </rule>
+        <rule id="3d03-8b14-7664-0b72" name="Curse of the Wulfen - Kill table" hidden="false" book="Curse of the Wulfen" page="52">
+          <description>(See Curse of the Wulfen special rule to determine affected units)
+1-3: Preternatural Swiftness
+Add 1 to the Initiative characteristic of models in affected units.
+4-5: Wild Savagery
+Models in affected units can re-roll all failed To Wound rolls in close combat.
+6: Unstoppable Fury
+Models in affected unitsthat are slain in the Fight sub-phase can, at the end of the current Initiative step, pile in and fight before being removed as casualties. Affected models can do this even if they have already fought that phase.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -35306,7 +35418,7 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
         </link>
       </links>
     </entry>
-    <entry id="4888-e98d-58e2-0907" name="Wulfen Murderpack" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="17">
+    <entry id="4888-e98d-58e2-0907" name="Wulfen Murderpack" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="43">
       <entries/>
       <entryGroups>
         <entryGroup id="501e-8dd9-a6dc-8911" name="2-5 Wulfen Packs" defaultEntryId="37e3-be6d-81ad-86f7" minSelections="2" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -35321,12 +35433,48 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
         </entryGroup>
       </entryGroups>
       <modifiers/>
-      <rules/>
+      <rules>
+        <rule id="e1df-4305-e362-d9d3" name="Infectious Ferocity" hidden="false" book="Curse of the Wulfen" page="43">
+          <description>Add 1 to any rolls on the Hunt and/or Kill tables for each unit from a Wulfen Murderpack on the battlefield after the first. If this results in a total of 7 or more, use the results below instead of the ones in the regular Hunt/Kill tables.
+HUNT (7+): Alpha Hunters
+Affected units can immediately make a free move as if it were the Movement phase.
+KILL (7+): Frenzied Murder-make
+Models in affected units add 1 to their Attack characteristic.</description>
+          <modifiers/>
+        </rule>
+        <rule id="b151-d6f4-06ec-c098" name="Orgy of Slaughter" hidden="false" book="Curse of the Wulfen" page="43">
+          <description>Each time a model from a Wulfen Murderpack rolls a 6 To Hit in close combat, it can immediately make one additional Attack.</description>
+          <modifiers/>
+        </rule>
+      </rules>
       <profiles/>
       <links/>
     </entry>
-    <entry id="aa5b-10b5-7ac3-bec4" name="Wyrdstorm Brotherhood" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="19">
-      <entries/>
+    <entry id="aa5b-10b5-7ac3-bec4" name="Wyrdstorm Brotherhood" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="46">
+      <entries>
+        <entry id="2916-27a6-d443-c2bd" name="The Living Storm" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="1573-8da4-cbfe-6467" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Living Storm" hidden="false" book="Curse of the Wulfen" page="46">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Witchfire, Warp Charge 3, Assault 2D6, Shock"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="00d4-b7e7-d555-29e1" targetId="5dd2553b-453d-6edc-c58b-c56996395761" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
       <entryGroups>
         <entryGroup id="0a74-3bf2-4c17-6999" name="2-5 Rune Priests" defaultEntryId="02e6-a7d8-8a20-41c8" minSelections="2" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -35337,6 +35485,34 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
               <modifiers/>
             </link>
             <link id="239b-86fa-283b-4708" targetId="d1420b7a-0039-8476-0480-1537bc1bd731" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="07c3-8dd4-f27e-6255" name="Masters of the Wyrdstorm" hidden="false" book="Curse of the Wulfen" page="46">
+          <description>Models from a Wyrdstorm Brotherhood harness Warp Charge points on a result of 3+ when attempting to manifest psychic powers from the Tempestas discipline or The Living Storm psychic power, which is a unique witchfire power from the Tempestas discipline.</description>
+          <modifiers/>
+        </rule>
+        <rule id="9b13-74c3-cd53-c03a" name="The Eye of the Storm" hidden="false" book="Curse of the Wulfen" page="46">
+          <description>At the start of each of your Psychic phases, select one model from the Wyrdstorm Brotherhood to be the Eye of the Storm. That model can attempt to manifest The Living Storm psychic power. Increase the Attacks rolled by D6 for each other Rune Priest in the Wyrdstorm Brotherhood that is on the battlefield.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="da70-8847-b78e-2abc" name="The Curseborn" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="31">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="aaa5-2812-3f1b-eb76" name="Murderfang" defaultEntryId="db79-1b19-0d52-b123" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="db79-1b19-0d52-b123" targetId="e5e9e3ff-a78b-721c-7ec9-f92745577bc0" linkType="entry">
               <modifiers/>
             </link>
           </links>
@@ -41282,6 +41458,10 @@ Models in a unit that includes one or more models equipped with stormfrag auto-l
     <rule id="decad1e9-1cb7-a7da-0261-4a12948eae91" name="+1 Damage" hidden="false" book="Imperial Armour Apocalypse 2013" page="19">
       <modifiers/>
     </rule>
+    <rule id="c497-8813-3ae2-7e77" name="A Gathering of Ancients" hidden="false" book="Curse of the Wulfen" page="47">
+      <description>All of the Dreadnoughts from the Ancients of the Fang must be fielded as a single Vehicle Squadron as described in the Warhammer 40K rulebook. However, whilst this formation includes three or more Dreadnoughts, they can all re-roll failed To Hit rolls in close combat.</description>
+      <modifiers/>
+    </rule>
     <rule id="9ddeb747-dd42-e0e3-df16-b524ad688ce0" name="A Glorious Death" hidden="false" book="Codex: Space Wolves" page="65">
       <description>Lone Wolf units are never scoring units.</description>
       <modifiers/>
@@ -41367,6 +41547,10 @@ If a model makes a shooting attack with a weapon that has this special rule, it 
     </rule>
     <rule id="84d6d926-64b0-accb-7d78-1b85870f6940" name="Blessing of Russ" hidden="false" book="Champions of Fenris">
       <description>As long as a Dreadnought from this Formation remains within 6&quot; of Bjorn the Fell-Handed, it has a 5+ invulnerable save. </description>
+      <modifiers/>
+    </rule>
+    <rule id="0293-590a-29b9-d274" name="Blessings of the Iron Wolf" hidden="false" book="Curse of the Wulfen" page="47">
+      <description>Dreadnoughts from the Ancients of the Fang have the It Will Not Die special rule whilst they are within 6&quot; of their Iron Priest.</description>
       <modifiers/>
     </rule>
     <rule id="33e3-266d-6bc6-69ba" name="Blind" hidden="false">
@@ -42241,6 +42425,10 @@ Cover save bonuses from the Shrouded and Stealth special rules are cumulative (t
       <description>If Lukas the Trickster is removed as a casualty whilst fighting a challenge, both players roll-off immediately – if the Space Wolves player wins, Lukas the Trickster’s opponent is also removed as a casualty.</description>
       <modifiers/>
     </rule>
+    <rule id="0518-77dc-a444-9c9e" name="The Saga that Walks" hidden="false" book="Curse of the Wulfen" page="47">
+      <description>Friendly units with the Space Wolves faction within 6&quot; of a Dreadnought from the Ancients of the Fang have the Stubborn special rule.</description>
+      <modifiers/>
+    </rule>
     <rule id="bd6f1247-6723-06c7-3677-4763b61d53d3" name="Their Finest Hours" hidden="false" book="40k Apocalypse 2nd Ed" page="0">
       <modifiers/>
     </rule>
@@ -42414,16 +42602,20 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
     <rule id="a703466f-57e0-dc75-5ad4-bdd4a4e132e0" name="Wyrdbane" hidden="false" book="Codex: Space Wolves" page="53">
       <modifiers/>
     </rule>
-    <rule id="c497-8813-3ae2-7e77" name="A Gathering of Ancients" hidden="false" book="Curse of the Wulfen" page="47">
-      <description>All of the Dreadnoughts from the Ancients of the Fang must be fielded as a single Vehicle Squadron as described in the Warhammer 40K rulebook. However, whilst this formation includes three or more Dreadnoughts, they can all re-roll failed To Hit rolls in close combat.</description>
+    <rule id="8813-a4a2-87e6-3b6f" name="Counter-charge" hidden="true" book="Curse of the Wulfen" page="30">
+      <description>At the end of your opponent&apos;s Charge sub-phase, you can declare a charge with any unengaged units from this Detachment, so long as each enemy unit that you attempt to charge is locked in combat with another unit from this detachment. Any units that do so count as charging for all rules purposes.</description>
       <modifiers/>
     </rule>
-    <rule id="0293-590a-29b9-d274" name="Blessings of the Iron Wolf" hidden="false" book="Curse of the Wulfen" page="47">
-      <description>Dreadnoughts from the Ancients of the Fang have the It Will Not Die special rule whilst they are within 6&quot; of their Iron Priest.</description>
+    <rule id="f02c-52ec-cde2-14bb" name="The Howl of Wolves (CotW)" hidden="true" book="Curse of the Wulfen" page="30">
+      <description>If a Wolf Claw strike force includes two or more Greatpacks, or two or more of the same Legendary Greatpack, one including a Wolf Lord and the other including a Wolf Guard Battle Leader, then together they form a Great Company. As long as a Great Company&apos;s Wolf Lord is stil alive, all units in that model&apos;s Great Company have the Fear and Furious Charge special rules. NOTE: Logan Grimnar, Ragnar Blackmane, Harald Deathwolf or Wolf Lord Krom may be taken in place of a Wolf Lord.</description>
       <modifiers/>
     </rule>
-    <rule id="0518-77dc-a444-9c9e" name="The Saga that Walks" hidden="false" book="Curse of the Wulfen" page="47">
-      <description>Friendly units with the Space Wolves faction within 6&quot; of a Dreadnought from the Ancients of the Fang have the Stubborn special rule.</description>
+    <rule id="597f-6d8d-e61c-414a" name="The High King (CotW)" hidden="false" book="Curse of the Wulfen" page="41">
+      <description>At the start of each of your turns, choose one special rule from the following list: Furious Charge, Monster Hunter, Preferred Enemy, Relentless, Tank Hunters. All Champions of Fenris units within 12&quot; of Logan Grimnar gain this special rule until the start of your next turn.</description>
+      <modifiers/>
+    </rule>
+    <rule id="e347-4382-5902-74e6" name="Reaping Swings" hidden="false" book="Curse of the Wulfen" page="53">
+      <description>On a turn in which a model equipped with thisweapon charges, it strikes at its normal Initiative order in the ensuing combat. In any subsequent rounds of combat, the wielder strikes at the Initiative 1 step.</description>
       <modifiers/>
     </rule>
   </sharedRules>
@@ -43260,7 +43452,7 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="3218-5a09-ff85-624a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Frost Claws" hidden="false" book="Curse of the Wulfen">
+    <profile id="3218-5a09-ff85-624a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Frost Claws" hidden="false" book="Curse of the Wulfen" page="53">
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+1"/>
@@ -43314,7 +43506,7 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="cd82-e243-6e8d-dc15" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Great Frost Axe" hidden="false">
+    <profile id="cd82-e243-6e8d-dc15" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Great Frost Axe" hidden="false" book="Curse of the Wulfen" page="53">
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+3"/>
@@ -43494,7 +43686,7 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="3a95-c774-edd6-2d55" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Helfrost pistol" hidden="false">
+    <profile id="3a95-c774-edd6-2d55" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Helfrost Pistol" hidden="false" book="Curse of the Wulfen" page="53">
       <characteristics>
         <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
@@ -44893,9 +45085,9 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="ea4c-7569-acba-851f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Tempest Hammer" hidden="false">
+    <profile id="ea4c-7569-acba-851f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Tempest Hammer" hidden="false" book="Curse of the Wulfen" page="53">
       <characteristics>
-        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
         <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="X2"/>
         <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
         <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Helfrost, Specialist Weapon, Unwieldy"/>
@@ -45516,9 +45708,9 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
         </modifier>
       </modifiers>
     </profile>
-    <profile id="84799e86-4ef6-3ab1-847f-97bd42f54eba" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Wolf Helm of Russ" hidden="false" book="Codex: Space Wolves faq 1.0" page="0">
+    <profile id="84799e86-4ef6-3ab1-847f-97bd42f54eba" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Wolf Helm of Russ" hidden="false" book="Curse of the Wulfen" page="33">
       <characteristics>
-        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Any friendly unit with the Space Wolves faction with Line of Sight to Ulrik may re-roll failed Morale tests. Any enemy with the Independent Character rule wishing to allocate Close Combat Attacks to Ulrik must pass a Leadership test. If they fail, they may not attack at all that turn."/>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="All friendly units with the Space Wolves Faction within 12&quot; of Ulrik the Slayer have the Stubborn special rule."/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
- Added all formation rules to the new CotW formations and added the
  special rules where they were missing for units/models/weapons from
  CotW. Closes #1940
- Fixed issue with Fangs of the Tempest. Closes #1986
- Made sure all required formations are added to the corresponding slot
  Core/Command/Auxiliary
- Wolfguard Stormforce had to be changed because of the changes in the
  Stormfang entry
- Removed minSelection 1 from Ulrik the Slayer entry. It was causing a
  default selection of Ulrik in Lord of the Fang formation
