### PR TITLE
Space Wolves - Deathpack formation refactoring

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,51 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="62" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="63" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="8a94-f395-4595-1dc1" name="Grey Hunters" defaultEntryId="4713-d901-e68e-d862" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4713-d901-e68e-d862" targetId="e53b-cd3f-942c-e67e" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="7f0d-6da6-477c-148e" name="Thunderwolf Cavalry" defaultEntryId="67ae-968c-563d-c169" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="67ae-968c-563d-c169" targetId="8d2353b0-5f5b-42cd-ab74-9e84494197f6" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="6439-ad9f-d333-8443" name="Wolf Lord" defaultEntryId="b5c7-cae6-8a35-0fe4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="b5c7-cae6-8a35-0fe4" targetId="137b70f2-f9a8-a9d6-b386-8ad300b0ffbc" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles/>
       <links>
         <link id="7d2e-c425-4139-ee22" targetId="f598-bc29-d3c2-0183" linkType="rule">
           <modifiers/>
-        </link>
-        <link id="da08-58f5-59e8-3a49" targetId="137b70f2-f9a8-a9d6-b386-8ad300b0ffbc" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="75a2-fb6d-c9e3-bc13" targetId="e53b-cd3f-942c-e67e" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="a50f-94ab-35fc-3d97" targetId="8d2353b0-5f5b-42cd-ab74-9e84494197f6" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
         </link>
       </links>
     </entry>
@@ -27334,6 +27329,25 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="da70-8847-b78e-2abc" name="The Curseborn" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="31">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="aaa5-2812-3f1b-eb76" name="Murderfang" defaultEntryId="db79-1b19-0d52-b123" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="db79-1b19-0d52-b123" targetId="e5e9e3ff-a78b-721c-7ec9-f92745577bc0" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
     <entry id="2890-44a3-a6e2-cddd" name="The Deathwolves" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen">
       <entries/>
       <entryGroups>
@@ -35504,25 +35518,6 @@ Models in affected units add 1 to their Attack characteristic.</description>
       <profiles/>
       <links/>
     </entry>
-    <entry id="da70-8847-b78e-2abc" name="The Curseborn" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Curse of the Wulfen" page="31">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="aaa5-2812-3f1b-eb76" name="Murderfang" defaultEntryId="db79-1b19-0d52-b123" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="db79-1b19-0d52-b123" targetId="e5e9e3ff-a78b-721c-7ec9-f92745577bc0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
   </sharedEntries>
   <sharedEntryGroups>
     <entryGroup id="dcb15017-c76e-384f-ca1a-b3ce6a1b8c02" name="Aircraft Upgrades" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -40168,7 +40163,7 @@ Models in affected units add 1 to their Attack characteristic.</description>
         </link>
       </links>
     </entryGroup>
-    <entryGroup id="ee0798c9-2888-861f-e9ac-d41c80b22100" name="Weapons wl" defaultEntryId="559d48fb-4046-2b12-18e7-9b77f36f354f" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entryGroup id="ee0798c9-2888-861f-e9ac-d41c80b22100" name="Weapons wl" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="559d48fb-4046-2b12-18e7-9b77f36f354f" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -41600,6 +41595,10 @@ If, when charged, the unit was already locked in combat, the Counter-attack spec
     <rule id="7c3519d4-e084-0b4e-8d12-1a0ea3b38564" name="Counter-attack (Ld 10)" hidden="false" book="Imperial Armour Apocalypse 2013" page="19">
       <modifiers/>
     </rule>
+    <rule id="8813-a4a2-87e6-3b6f" name="Counter-charge" hidden="true" book="Curse of the Wulfen" page="30">
+      <description>At the end of your opponent&apos;s Charge sub-phase, you can declare a charge with any unengaged units from this Detachment, so long as each enemy unit that you attempt to charge is locked in combat with another unit from this detachment. Any units that do so count as charging for all rules purposes.</description>
+      <modifiers/>
+    </rule>
     <rule id="e60281e5-ed41-0d9d-ea4f-beb543420eaf" name="Crushing Weight" hidden="false" book="Imperial Armour II 2nd Ed" page="109">
       <modifiers/>
     </rule>
@@ -41737,7 +41736,7 @@ Roll a D6 each time an unsaved Wound is suffered. On a 5 or less, you must take 
       <modifiers/>
     </rule>
     <rule id="f598-bc29-d3c2-0183" name="For Glory, For Russ!" hidden="false" book="Start Collecting! Space Wolves">
-      <description>The Wolf Lord, and any units from the Deathpack that are within 12&quot; of him at the start of your Shooting Phase, can either shoot and re-roll to hit rolls of 1, or Run and still be able to charge in the same turn.  Different units can choose different options, so one unit could Run and charge, while another re-rolls to hit rolls of 1.</description>
+      <description>The Wolf Lord, and any units from the Deathpack that are within 12&quot; of him at the start of your Shooting Phase, can either shoot and re-roll to hit rolls of 1, or Run and still be able to charge in the same turn.  Different units can choose different options, so one unit could Run and charge, while another re-rolls hit rolls of 1.</description>
       <modifiers/>
     </rule>
     <rule id="33c662ba-71c4-144e-e181-3b0534d8f9af" name="For The Emperor!" hidden="true" book="40k Apocalypse 2nd Ed" page="0">
@@ -42240,6 +42239,10 @@ Jaws of the World Wolf is a focussed witchfire power that targets a single non-v
     <rule id="e62673a2-b8b7-53eb-1836-d08c880ab3be" name="Reactor Meltdown" hidden="false" book="Imperial Armour Apocalypse 2013" page="6">
       <modifiers/>
     </rule>
+    <rule id="e347-4382-5902-74e6" name="Reaping Swings" hidden="false" book="Curse of the Wulfen" page="53">
+      <description>On a turn in which a model equipped with thisweapon charges, it strikes at its normal Initiative order in the ensuing combat. In any subsequent rounds of combat, the wielder strikes at the Initiative 1 step.</description>
+      <modifiers/>
+    </rule>
     <rule id="f6c5e3e9-9d6b-df23-520c-cd54acbd4a19" name="Rebellious" hidden="false" book="Codex: Space Wolves" page="59">
       <description>Lukas the Trickster and his unit may never use a Leadership value higher than 8 for any tests they make.</description>
       <modifiers/>
@@ -42414,7 +42417,15 @@ Cover save bonuses from the Shrouded and Stealth special rules are cumulative (t
     <rule id="a28a16cc-c39e-0905-c7d5-449dafc2c556" name="The High King" hidden="false" book="Sanctus Reach: Hour of the Wolf" page="95">
       <modifiers/>
     </rule>
+    <rule id="597f-6d8d-e61c-414a" name="The High King (CotW)" hidden="false" book="Curse of the Wulfen" page="41">
+      <description>At the start of each of your turns, choose one special rule from the following list: Furious Charge, Monster Hunter, Preferred Enemy, Relentless, Tank Hunters. All Champions of Fenris units within 12&quot; of Logan Grimnar gain this special rule until the start of your next turn.</description>
+      <modifiers/>
+    </rule>
     <rule id="b6384a95-587b-dd70-9b48-13a0f3c5294e" name="The Howl of the Wolf" hidden="false" book="40k Apocalypse 2nd Ed" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="f02c-52ec-cde2-14bb" name="The Howl of Wolves (CotW)" hidden="true" book="Curse of the Wulfen" page="30">
+      <description>If a Wolf Claw strike force includes two or more Greatpacks, or two or more of the same Legendary Greatpack, one including a Wolf Lord and the other including a Wolf Guard Battle Leader, then together they form a Great Company. As long as a Great Company&apos;s Wolf Lord is stil alive, all units in that model&apos;s Great Company have the Fear and Furious Charge special rules. NOTE: Logan Grimnar, Ragnar Blackmane, Harald Deathwolf or Wolf Lord Krom may be taken in place of a Wolf Lord.</description>
       <modifiers/>
     </rule>
     <rule id="2786-f22b-6602-ae1e" name="The Howl of Wolves (formation)" hidden="false" book="Codex: Space Wolves">
@@ -42600,22 +42611,6 @@ The Warlord, and all friendly units with the Space Wolves Faction within 12&quot
       <modifiers/>
     </rule>
     <rule id="a703466f-57e0-dc75-5ad4-bdd4a4e132e0" name="Wyrdbane" hidden="false" book="Codex: Space Wolves" page="53">
-      <modifiers/>
-    </rule>
-    <rule id="8813-a4a2-87e6-3b6f" name="Counter-charge" hidden="true" book="Curse of the Wulfen" page="30">
-      <description>At the end of your opponent&apos;s Charge sub-phase, you can declare a charge with any unengaged units from this Detachment, so long as each enemy unit that you attempt to charge is locked in combat with another unit from this detachment. Any units that do so count as charging for all rules purposes.</description>
-      <modifiers/>
-    </rule>
-    <rule id="f02c-52ec-cde2-14bb" name="The Howl of Wolves (CotW)" hidden="true" book="Curse of the Wulfen" page="30">
-      <description>If a Wolf Claw strike force includes two or more Greatpacks, or two or more of the same Legendary Greatpack, one including a Wolf Lord and the other including a Wolf Guard Battle Leader, then together they form a Great Company. As long as a Great Company&apos;s Wolf Lord is stil alive, all units in that model&apos;s Great Company have the Fear and Furious Charge special rules. NOTE: Logan Grimnar, Ragnar Blackmane, Harald Deathwolf or Wolf Lord Krom may be taken in place of a Wolf Lord.</description>
-      <modifiers/>
-    </rule>
-    <rule id="597f-6d8d-e61c-414a" name="The High King (CotW)" hidden="false" book="Curse of the Wulfen" page="41">
-      <description>At the start of each of your turns, choose one special rule from the following list: Furious Charge, Monster Hunter, Preferred Enemy, Relentless, Tank Hunters. All Champions of Fenris units within 12&quot; of Logan Grimnar gain this special rule until the start of your next turn.</description>
-      <modifiers/>
-    </rule>
-    <rule id="e347-4382-5902-74e6" name="Reaping Swings" hidden="false" book="Curse of the Wulfen" page="53">
-      <description>On a turn in which a model equipped with thisweapon charges, it strikes at its normal Initiative order in the ensuing combat. In any subsequent rounds of combat, the wielder strikes at the Initiative 1 step.</description>
       <modifiers/>
     </rule>
   </sharedRules>


### PR DESCRIPTION
- Instead of direct links with modifiers, the units are now put into
  entry groups with the required min/max limitations
- Removed default selection of Bolt Pistols in the Wolf Lord weapons
  group
  Closes #1982
