### PR TITLE
Space Wolves - formation fixes

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="66" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="67" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
@@ -22467,6 +22467,90 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="fc08-e447-e49a-24c4" name="Krom Dragongaze, The Fierce-Eye" points="150.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Sanctus Reach: Stormclaw" page="18">
+      <entries>
+        <entry id="ff58-8bc5-ce6a-4320" name="Relic: Wyrmclaw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="5e34-5917-3032-380b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Wyrmclaw" hidden="false" book="Sanctus Reach: Stormclaw" page="18">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+2"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Master-crafted, Unwieldy"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers>
+        <modifier type="set" field="maxInRoster" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="roster" childId="bfdc-f5c5-672a-f356" field="selections" type="at least" value="1.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <rules/>
+      <profiles>
+        <profile id="82d8-5d7f-f102-1c57" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Krom Dragongaze, The Fierce-Eye" hidden="false" book="Sanctus Reach: Stormclaw" page="18">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character) "/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+/4++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="0711-9c54-5603-30a7" targetId="74d72175-8c6f-57a0-56d0-bb498cb5e030" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1e8c-4af8-371f-64c6" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6320-9747-8804-261c" targetId="e9cfe9f3-9259-1e61-7c53-9f6147e5bee9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="bd2d-f06b-9f65-d965" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1bd3-43d3-8811-5758" targetId="9ba00ec4-2c72-2463-c497-b706c5ab98f9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="2af2-a605-dcbc-2231" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="00f4-16d3-c3ff-4842" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="876a-452a-83ae-f3cc" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9f51-085b-de45-e9e9" targetId="98d356a2-8d8b-af1a-4228-90d7d1e6d45a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9ec3-f0e7-961a-5046" targetId="cb0122dd-c2e2-3881-4e57-4840e8f3346c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8672-9008-ab26-d0e6" targetId="d3fb2835-5b64-beb7-c844-df8ddc84a8ac" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="838cc1a0-1c83-a413-5e99-d10376c1e037" name="Land Raider" points="250.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="85">
       <entries>
         <entry id="fc07921b-1cbc-6338-fb87-21fc8f0f667c" name="Twin-Linked Lascannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -26679,6 +26763,83 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="3394-d9b2-b771-5506" name="Strike Force Daggerfist" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="cb20-8a85-f345-0f47" name="Murderfang" defaultEntryId="f85d-df5a-726b-3819" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="f85d-df5a-726b-3819" targetId="e5e9e3ff-a78b-721c-7ec9-f92745577bc0" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="5e3e-1e2e-15b9-56f4" name="1 unit of Wulfen" defaultEntryId="5858-a2aa-bc9c-8ab7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="5858-a2aa-bc9c-8ab7" targetId="b39d-6620-f7b8-b856" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="5834-d69c-272f-c2de" name="1 unit of Wolf Guard" defaultEntryId="b13e-acfd-18c8-d9d1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="b13e-acfd-18c8-d9d1" targetId="1d43-2aba-90d3-edc9" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="74b5-421f-0d45-9e3f" name="3 units of Wolf Guard Terminators" defaultEntryId="1781-f0bc-5163-1127" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1781-f0bc-5163-1127" targetId="b644a899-4226-4b28-a533-6a648bf93e46" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="d556-a3c0-a459-ddf0" name="1 Stormfang Gunship" defaultEntryId="06f0-8d2c-7ee9-136e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="06f0-8d2c-7ee9-136e" targetId="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="518f-0c2a-60ba-3e50" name="Kingsguard" hidden="false">
+          <description>The following Strike Force Daggerfist models have +1 Weapon Skill on their profile:
+
+- Wolf Guard
+- Wolf Guard Pack Leader
+- Wolf Guard Terminator
+- Wolf Guard Terminator Leader</description>
+          <modifiers/>
+        </rule>
+        <rule id="6b19-9d19-fe1c-7afb" name="Wulfenkin" hidden="false">
+          <description>Add 1 to the Attacks of any Strike Force Daggerfist model whose unit is within 6&quot; of the Formation&apos;s unit of Wulfen at the start of the Assault phase. This effect lasts until the end of the phase.</description>
+          <modifiers/>
+        </rule>
+        <rule id="39fd-37ed-cef6-b094" name="Oath of Protection" hidden="false">
+          <description>Enemy units can only target Strike Force Daggerfist&apos;s unit of Wulfen if they are the closest target from this Formation to the attacking unit.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
     <entry id="b66e181f-a932-2f91-d2c3-a2c9b756fb12" name="Swiftclaws" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="71">
       <entries>
         <entry id="7d364e51-a497-1483-2313-0334c0ece389" name="Swiftclaw Attack Bike" points="35.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -27966,7 +28127,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="9063-49a7-dc43-73ab" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="9063-49a7-dc43-73ab" name="Weapon" defaultEntryId="43c3-c935-c4f4-e46e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="cdc7-94b3-88f2-1157" name="Deathwind Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -28096,7 +28257,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     <entry id="f677-fd8d-372f-fecc" name="Razorback" points="55.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="73">
                       <entries/>
                       <entryGroups>
-                        <entryGroup id="264e-d4c2-b4da-066c" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="264e-d4c2-b4da-066c" name="Weapon" defaultEntryId="f984-0f52-c8af-1735" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="d683-a29f-cae4-2e2a" name="Twin-linked Heavy Flamer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -28374,14 +28535,22 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                                 </link>
                               </links>
                             </entry>
+                            <entry id="2477-9b7e-6821-6560" name="Hunter-killer Missile" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="f9ac-ab43-1141-880d" targetId="993442fa-6e0a-526d-543a-34cb27ca5e61" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
                           </entries>
                           <entryGroups/>
                           <modifiers/>
-                          <links>
-                            <link id="b9f6-b726-35e2-016c" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
-                              <modifiers/>
-                            </link>
-                          </links>
+                          <links/>
                         </entryGroup>
                       </entryGroups>
                       <modifiers/>
@@ -28462,14 +28631,22 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                                 </link>
                               </links>
                             </entry>
+                            <entry id="ffc4-1419-5244-8cbd" name="Hunter-killer Missile" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="d943-4b2b-6bda-3a12" targetId="993442fa-6e0a-526d-543a-34cb27ca5e61" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
                           </entries>
                           <entryGroups/>
                           <modifiers/>
-                          <links>
-                            <link id="6b37-7936-a44a-3f4c" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
-                              <modifiers/>
-                            </link>
-                          </links>
+                          <links/>
                         </entryGroup>
                       </entryGroups>
                       <modifiers/>
@@ -28553,14 +28730,22 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                                 </link>
                               </links>
                             </entry>
+                            <entry id="15c7-d06c-1515-0d38" name="Hunter-killer Missile" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="b045-9923-bd22-901e" targetId="993442fa-6e0a-526d-543a-34cb27ca5e61" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
                           </entries>
                           <entryGroups/>
                           <modifiers/>
-                          <links>
-                            <link id="bd61-9d32-369b-e184" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
-                              <modifiers/>
-                            </link>
-                          </links>
+                          <links/>
                         </entryGroup>
                       </entryGroups>
                       <modifiers/>
@@ -28590,6 +28775,108 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </link>
                       </links>
                     </entry>
+                    <entry id="dd33-b261-27b0-2c8f" name="Stormwolf" points="215.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="75">
+                      <entries>
+                        <entry id="d649-29e9-958f-de7c" name="Twin-linked Helfrost Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="c933-aa2b-18e2-b04d" targetId="1c80cd55-1747-7686-5136-2dc05f89260a" linkType="profile">
+                              <modifiers/>
+                            </link>
+                            <link id="818d-5f83-07b7-2b5b" targetId="da4cc1e9-9855-01d0-f968-d551470dce58" linkType="rule">
+                              <modifiers/>
+                            </link>
+                            <link id="2671-8a1f-4db9-45bb" targetId="bf5dece1-635f-1d70-1adf-9a6955da63f0" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="36d1-24c0-15e6-853e" name="Fighter Ace" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Shield of Baal: Leviathan" page="44">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="19f0-44a6-45a5-dc65" targetId="0659c2f0-2ade-4c75-631f-ff484780df39" linkType="rule">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                      </entries>
+                      <entryGroups>
+                        <entryGroup id="228d-1152-cd87-b692" name="Sponsons" defaultEntryId="14da-cd23-d53e-6969" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                          <entries>
+                            <entry id="14da-cd23-d53e-6969" name="2x Twin-linked Heavy Bolters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="70aa-675f-ff2f-3305" targetId="86ab4a73-4680-4c6a-007d-3c6823bd2599" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
+                            <entry id="9be7-0575-586b-b93b" name="Skyhammer Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="89f7-301a-625d-b463" targetId="f8893b01-d20e-5721-520b-de45867f2950" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
+                            <entry id="354d-31be-1008-c1c9" name="2x Twin-linked Multi-Meltas" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="956c-5321-97f0-dd9e" targetId="3669bc8e-6361-f774-268f-ad6a4dd09afb" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
+                          </entries>
+                          <entryGroups/>
+                          <modifiers/>
+                          <links/>
+                        </entryGroup>
+                      </entryGroups>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="2710-2063-d956-740d" targetId="89fa83a7-de52-7807-32c6-b3fe45f2ae58" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="6ab1-a177-7670-732c" targetId="eb95dad9-5e29-2474-4d99-3874751f67c1" linkType="rule">
+                          <modifiers/>
+                        </link>
+                        <link id="50d4-5c3e-1104-0e82" targetId="c800c5e2-98af-b5e4-b226-1c13a1c72125" linkType="rule">
+                          <modifiers/>
+                        </link>
+                        <link id="98ac-3966-a261-9e54" targetId="2dbae37d-01b7-170b-d5ee-036461e83917" linkType="rule">
+                          <modifiers/>
+                        </link>
+                        <link id="f583-af5c-3e99-fc0e" targetId="8bb528ac-f996-7c60-68ce-394f932a961a" linkType="entry">
+                          <modifiers/>
+                        </link>
+                        <link id="0009-5ca3-b433-1f10" targetId="70f80873-35ce-7c81-33e5-6da2d0253a31" linkType="entry">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
                   </entries>
                   <entryGroups/>
                   <modifiers/>
@@ -28610,9 +28897,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   <modifiers/>
                 </link>
                 <link id="081f-b6a3-8ad0-d4a8" targetId="73fa989d-171c-0f61-78ec-cc9ba0f78553" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="6c21-b1ec-7955-8b8e" targetId="fb0ec32c-de76-2a01-2e24-9c614b8f404c" linkType="entry group">
                   <modifiers/>
                 </link>
               </links>
@@ -28729,7 +29013,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="2cb8-c45c-fc7d-5772" name="Sponsons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="2cb8-c45c-fc7d-5772" name="Sponsons" defaultEntryId="354a-c67f-251c-9b41" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="354a-c67f-251c-9b41" name="2x Twin-linked Heavy Bolters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -28851,14 +29135,22 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                                 </link>
                               </links>
                             </entry>
+                            <entry id="3e2d-b329-2301-a396" name="Hunter-killer Missile" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="8ad2-9706-b00d-30ba" targetId="993442fa-6e0a-526d-543a-34cb27ca5e61" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
                           </entries>
                           <entryGroups/>
                           <modifiers/>
-                          <links>
-                            <link id="e291-32da-9abb-2d93" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
-                              <modifiers/>
-                            </link>
-                          </links>
+                          <links/>
                         </entryGroup>
                       </entryGroups>
                       <modifiers/>
@@ -28939,14 +29231,22 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                                 </link>
                               </links>
                             </entry>
+                            <entry id="ef7a-fde0-793e-1a85" name="Hunter-killer Missile" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="f688-c914-c94e-5be4" targetId="993442fa-6e0a-526d-543a-34cb27ca5e61" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
                           </entries>
                           <entryGroups/>
                           <modifiers/>
-                          <links>
-                            <link id="4dd4-7c67-881a-0a47" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
-                              <modifiers/>
-                            </link>
-                          </links>
+                          <links/>
                         </entryGroup>
                       </entryGroups>
                       <modifiers/>
@@ -29030,14 +29330,22 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                                 </link>
                               </links>
                             </entry>
+                            <entry id="f820-7ca5-95f5-7a2d" name="Hunter-killer Missile" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                              <entries/>
+                              <entryGroups/>
+                              <modifiers/>
+                              <rules/>
+                              <profiles/>
+                              <links>
+                                <link id="ee23-a01a-b46b-b5a5" targetId="993442fa-6e0a-526d-543a-34cb27ca5e61" linkType="profile">
+                                  <modifiers/>
+                                </link>
+                              </links>
+                            </entry>
                           </entries>
                           <entryGroups/>
                           <modifiers/>
-                          <links>
-                            <link id="3f93-9104-ef3f-99a6" targetId="f2d93014-59c8-c214-d4c4-02bf2f7a7961" linkType="entry">
-                              <modifiers/>
-                            </link>
-                          </links>
+                          <links/>
                         </entryGroup>
                       </entryGroups>
                       <modifiers/>
@@ -29070,11 +29378,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                   </entries>
                   <entryGroups/>
                   <modifiers/>
-                  <links>
-                    <link id="dc76-f2aa-3cf8-a3ed" targetId="fa53d0f0-97b1-05f8-2398-c8b835c63b4b" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
+                  <links/>
                 </entryGroup>
                 <entryGroup id="bf26-5671-fc2c-c2cf" name="Wolf Guard Terminator Leader" defaultEntryId="da71-b486-a733-0519" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
@@ -29530,7 +29834,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="a29f-0b20-d1e9-e78f" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="a29f-0b20-d1e9-e78f" name="Weapon" defaultEntryId="ae64-2c48-0c77-ea45" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="7a35-35d3-26f7-fe25" name="Deathwind Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -29660,7 +29964,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     <entry id="5bd2-0d9f-592e-d41d" name="Razorback" points="55.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="73">
                       <entries/>
                       <entryGroups>
-                        <entryGroup id="da8c-3b91-6197-6f58" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="da8c-3b91-6197-6f58" name="Weapon" defaultEntryId="a930-61bf-9634-e3c3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="982c-ef41-b750-7bde" name="Twin-linked Heavy Flamer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -29918,7 +30222,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="6eb1-c05c-3e34-91c9" name="Sponsons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="6eb1-c05c-3e34-91c9" name="Sponsons" defaultEntryId="4f2f-60e2-19e7-59e7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="4f2f-60e2-19e7-59e7" name="2x Twin-linked Heavy Bolters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -30231,7 +30535,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="fb07-5d39-420a-baad" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="fb07-5d39-420a-baad" name="Weapon" defaultEntryId="2b3c-b851-a2a6-bfaa" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="4aa9-91c4-7243-d9c6" name="Deathwind Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -30361,7 +30665,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     <entry id="6f03-c690-fc73-15b3" name="Razorback" points="55.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="73">
                       <entries/>
                       <entryGroups>
-                        <entryGroup id="178d-d2ef-28fa-62e0" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="178d-d2ef-28fa-62e0" name="Weapon" defaultEntryId="b004-2a3f-ebe5-04e6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="8e5e-a699-6f49-c819" name="Twin-linked Heavy Flamer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -30619,7 +30923,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="c4c1-7e05-6585-d62d" name="Sponsons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="c4c1-7e05-6585-d62d" name="Sponsons" defaultEntryId="ff42-9611-3c1a-dad1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="ff42-9611-3c1a-dad1" name="2x Twin-linked Heavy Bolters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -31172,7 +31476,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                         </entry>
                       </entries>
                       <entryGroups>
-                        <entryGroup id="0514-3a6c-9e16-c80c" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="0514-3a6c-9e16-c80c" name="Weapon" defaultEntryId="610a-a359-5394-78ed" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="f0af-22e4-5e1b-0915" name="Deathwind Missile Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -31302,7 +31606,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     <entry id="5fff-e5b7-40b3-5e8d" name="Razorback" points="55.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="73">
                       <entries/>
                       <entryGroups>
-                        <entryGroup id="7555-88ee-4311-dd8c" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entryGroup id="7555-88ee-4311-dd8c" name="Weapon" defaultEntryId="53c1-12b6-ebe6-228c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries>
                             <entry id="fabe-0283-9a14-d5cb" name="Twin-linked Heavy Flamer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                               <entries/>
@@ -35414,167 +35718,6 @@ Models in affected units add 1 to their Attack characteristic.</description>
       </rules>
       <profiles/>
       <links/>
-    </entry>
-    <entry id="3394-d9b2-b771-5506" name="Strike Force Daggerfist" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="cb20-8a85-f345-0f47" name="Murderfang" defaultEntryId="f85d-df5a-726b-3819" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f85d-df5a-726b-3819" targetId="e5e9e3ff-a78b-721c-7ec9-f92745577bc0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5e3e-1e2e-15b9-56f4" name="1 unit of Wulfen" defaultEntryId="5858-a2aa-bc9c-8ab7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="5858-a2aa-bc9c-8ab7" targetId="b39d-6620-f7b8-b856" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5834-d69c-272f-c2de" name="1 unit of Wolf Guard" defaultEntryId="b13e-acfd-18c8-d9d1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b13e-acfd-18c8-d9d1" targetId="1d43-2aba-90d3-edc9" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="74b5-421f-0d45-9e3f" name="3 units of Wolf Guard Terminators" defaultEntryId="1781-f0bc-5163-1127" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1781-f0bc-5163-1127" targetId="b644a899-4226-4b28-a533-6a648bf93e46" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="d556-a3c0-a459-ddf0" name="1 Stormfang Gunship" defaultEntryId="06f0-8d2c-7ee9-136e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="06f0-8d2c-7ee9-136e" targetId="7d3cec99-c2c1-1c49-2cd4-8a60ab420185" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="518f-0c2a-60ba-3e50" name="Kingsguard" hidden="false">
-          <description>The following Strike Force Daggerfist models have +1 Weapon Skill on their profile:
-
-- Wolf Guard
-- Wolf Guard Pack Leader
-- Wolf Guard Terminator
-- Wolf Guard Terminator Leader</description>
-          <modifiers/>
-        </rule>
-        <rule id="6b19-9d19-fe1c-7afb" name="Wulfenkin" hidden="false">
-          <description>Add 1 to the Attacks of any Strike Force Daggerfist model whose unit is within 6&quot; of the Formation&apos;s unit of Wulfen at the start of the Assault phase. This effect lasts until the end of the phase.</description>
-          <modifiers/>
-        </rule>
-        <rule id="39fd-37ed-cef6-b094" name="Oath of Protection" hidden="false">
-          <description>Enemy units can only target Strike Force Daggerfist&apos;s unit of Wulfen if they are the closest target from this Formation to the attacking unit.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="fc08-e447-e49a-24c4" name="Krom Dragongaze, The Fierce-Eye" points="150.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Sanctus Reach: Stormclaw" page="18">
-      <entries>
-        <entry id="ff58-8bc5-ce6a-4320" name="Relic: Wyrmclaw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="5e34-5917-3032-380b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Wyrmclaw" hidden="false" book="Sanctus Reach: Stormclaw" page="18">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+2"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Master-crafted, Unwieldy"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInRoster" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="bfdc-f5c5-672a-f356" field="selections" type="at least" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles>
-        <profile id="82d8-5d7f-f102-1c57" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Krom Dragongaze, The Fierce-Eye" hidden="false" book="Sanctus Reach: Stormclaw" page="18">
-          <characteristics>
-            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character) "/>
-            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
-            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
-            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
-            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
-            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
-            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
-            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
-            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
-            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+/4++"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="0711-9c54-5603-30a7" targetId="74d72175-8c6f-57a0-56d0-bb498cb5e030" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1e8c-4af8-371f-64c6" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6320-9747-8804-261c" targetId="e9cfe9f3-9259-1e61-7c53-9f6147e5bee9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="bd2d-f06b-9f65-d965" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="1bd3-43d3-8811-5758" targetId="9ba00ec4-2c72-2463-c497-b706c5ab98f9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="2af2-a605-dcbc-2231" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="00f4-16d3-c3ff-4842" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="876a-452a-83ae-f3cc" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9f51-085b-de45-e9e9" targetId="98d356a2-8d8b-af1a-4228-90d7d1e6d45a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9ec3-f0e7-961a-5046" targetId="cb0122dd-c2e2-3881-4e57-4840e8f3346c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8672-9008-ab26-d0e6" targetId="d3fb2835-5b64-beb7-c844-df8ddc84a8ac" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
     </entry>
   </sharedEntries>
   <sharedEntryGroups>

--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -17583,7 +17583,18 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="ba65-f4e5-187c-5d4a" name="Bjorn the Fell-Handed" defaultEntryId="c6f8-ce7f-14a4-46a6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="c6f8-ce7f-14a4-46a6" targetId="f9a0332f-3829-e428-fe50-620d178abda4" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -17601,9 +17612,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </link>
         <link id="bbda418a-0502-6fb7-5fc0-5a0f1c4cf826" targetId="aa9270d8-c94a-1b2c-4cce-532a57653e93" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="9d73de51-81a0-ae59-20db-4df41e663ff5" targetId="f9a0332f-3829-e428-fe50-620d178abda4" linkType="entry">
           <modifiers/>
         </link>
       </links>


### PR DESCRIPTION
- Fixed vehicles, default selections and vehicle upgrades in "The Ironwolves" formation
  Closes #2002 
- Fixed "Brethren of the Fell-Handed"
  Closes #2001 
