### PR TITLE
Space Wolves - Fixed Grimnar's War Council

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="69" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="70" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
@@ -17618,161 +17618,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
     </entry>
     <entry id="02d23b67-25bc-1b4e-5b34-9e8572fc4d28" name="&quot;Grimnar&apos;s War Council&quot;" points="0.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Champions of Fenris">
       <entries>
-        <entry id="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" name="Iron Priest" points="55.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="62">
-          <entries>
-            <entry id="695bfc0f-ca3b-0fb0-c1a0-aa5ab9ae7e86" name="Cyberwolf" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="63065e60-a558-0235-5160-0d009521a1e1" targetId="bccb30ea-1d81-8094-9f85-a7c1a3f143ee" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="2a26864a-a0fe-20df-2abc-c53a5094fc7c" targetId="f31a9743-91e7-e551-ec6f-c3154bc7637c" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="8f8f3b9e-277f-d844-be77-41893c3c9432" name="Mount" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b8c0b610-651d-9c5f-c33b-7f1552f1273c" targetId="321fc9cb-f174-d346-b74a-7d3e22ced25b" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1a9ec245-51ea-2fd4-4748-a4a6f7460ded" targetId="61c3ce14-af2b-4ffa-9c3f-ba7158743f4b" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="dd6dfcdd-3512-922f-9fcf-3cea1c7d1793" name="Weapon" defaultEntryId="a78f8714-f3e5-dfe1-0071-35702dc0e3d1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="cbe16dbb-a28b-a899-faa7-d9a81025b172" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="d66a98b0-a187-769b-39e7-d6a03ccfb5ca" targetId="82de7a82-9e87-8dc1-6d88-fbe1ee0c024c" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="a78f8714-f3e5-dfe1-0071-35702dc0e3d1" name="Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="c9384a71-fea8-72f9-6f8b-127153a080bb" targetId="df2c46a5-cbaa-46c8-c4e6-fa4c1f30df51" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="db03781e-d362-bd18-156c-329e0a2ea1bc" targetId="44e0993d-4c19-297a-837a-869e17e25c12" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="59971de4-daa9-a6da-8cce-2a765ef19f06" targetId="913d454d-f14f-5c77-2f4a-97bcf531c2f3" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="76f4afa1-9f8c-5a08-4d84-9dd918ee2fcf" targetId="7325dbb8-81ee-1150-735d-3c00808e39b3" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="83c86de7-3c00-3052-2e09-18ef8153af51" targetId="4ae74762-7a29-c4d0-11f9-635fb7f65c31" linkType="profile">
-              <modifiers>
-                <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="61c3ce14-af2b-4ffa-9c3f-ba7158743f4b" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="321fc9cb-f174-d346-b74a-7d3e22ced25b" field="selections" type="equal to" value="1.0"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-                <modifier type="increment" field="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="321fc9cb-f174-d346-b74a-7d3e22ced25b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="321fc9cb-f174-d346-b74a-7d3e22ced25b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Cavalry (Character)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="321fc9cb-f174-d346-b74a-7d3e22ced25b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bike (Character)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="61c3ce14-af2b-4ffa-9c3f-ba7158743f4b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="3b2ef2ac-50ca-ae4f-485c-3322f6d4b948" childId="321fc9cb-f174-d346-b74a-7d3e22ced25b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="69bdc5a0-e655-2b1a-1610-02076d300acc" targetId="f911c47d-1eef-7161-64d9-4f6e706f8e48" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b6ce28b1-1fa7-742f-621d-247a0822d888" targetId="7b55b3bd-82f8-a73f-131c-0bcd40479b9e" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b997df99-0350-6794-780f-5490e00b17d8" targetId="89e93048-6597-4b88-9bf5-f257aed752c4" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2ea95415-375c-a640-0cb6-ac5ab1c41a1c" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="61f22339-3366-2d36-3baf-c7440546de69" targetId="c50b8cd4-1671-2744-02dd-1c08ea726dc1" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="258dc124-2ac0-caca-6c80-6cc7902b7cca" targetId="cced9ed8-8f70-90d6-ef2f-5dfd4c956e2e" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a740f8a3-8835-95b4-0891-3fda0f62d7e4" targetId="817d1d89-a150-658d-837c-02417b24437b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ed6df745-c037-a0b0-89e9-46e90c0d2dcb" targetId="d791dd4c-fba5-7cb5-cee6-3dfbea870a14" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c6d15d89-152d-66da-7376-217a22ef97b2" targetId="65e2ebff-7328-b852-21a9-9a1c5f48cbbd" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="29cd7894-b2c3-b911-3034-57664f20332f" targetId="040be134-c1a1-4bac-fa50-7ad00bfe0ae4" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
         <entry id="70392e88-5b6b-dca0-7133-bd36636338df" name="Rune Priest" points="60.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Space Wolves" page="52">
           <entries>
             <entry id="fa575e33-366e-e028-0a81-f4dbbcfe63f2" name="Psychic Hood" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -18003,7 +17848,41 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="b240-8c5a-2544-9bf5" name="Iron Priest" defaultEntryId="9189-c6d2-6f8c-a910" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="9189-c6d2-6f8c-a910" targetId="eab714a3-18ea-822a-f117-be2f452edaae" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7baf-d15d-e497-1669" targetId="5b96-9766-6096-d837" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="a09b-5a09-84b0-082c" name="Ulrik the Slayer, Wolf High Priest" defaultEntryId="7c1f-5cdb-79d7-7e83" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="7c1f-5cdb-79d7-7e83" targetId="fa230f5b-ee25-91a6-5bdb-4c50f298b47b" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="02f1-38a5-da59-6b58" name="Njal Stormcaller, the Tempest that Walks" defaultEntryId="4693-559d-a797-2d9e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4693-559d-a797-2d9e" targetId="d1420b7a-0039-8476-0480-1537bc1bd731" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles/>
@@ -18027,12 +17906,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <modifiers/>
         </link>
         <link id="2248a185-f286-a753-5413-7da6d30bed72" targetId="aa9270d8-c94a-1b2c-4cce-532a57653e93" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="690edcea-da7d-9519-28ff-00dc1fabe32a" targetId="fa230f5b-ee25-91a6-5bdb-4c50f298b47b" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="f79b0c7f-162c-1e58-88fb-dfe7de503b68" targetId="d1420b7a-0039-8476-0480-1537bc1bd731" linkType="entry">
           <modifiers/>
         </link>
       </links>


### PR DESCRIPTION
- Reworked the formation because it was a mess
- Ulrik and Njal are now mandatory, as per the formation in the
  supplement
- The IP and RP now link to the shared entries instead of having the
  entire profile copy-pasted
- The user can choose to use the new IP (selected by default) or the old
  one, as agreed

Closes #2150
