### PR TITLE
KDK v60 - Corrected Spelling of Invulnerable

### DIFF
--- a/Chaos - Khorne Daemonkin.cat
+++ b/Chaos - Khorne Daemonkin.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9b32-f1cf-7ad4-9ca1" revision="59" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="17" battleScribeVersion="1.15" name="Chaos - Khorne Daemonkin" authorName="BSData Team" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9b32-f1cf-7ad4-9ca1" revision="60" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="17" battleScribeVersion="1.15" name="Chaos - Khorne Daemonkin" authorName="BSData Team" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="09fd-7e29-0ff2-82d5" name="Blood Tithe reference table" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
@@ -329,7 +329,7 @@ Tithe Costs/Bonus
           <modifiers/>
         </rule>
         <rule id="f44d-2293-0b31-13ef" name="Daemon Lord" hidden="false">
-          <description>The invunerable save is 3+</description>
+          <description>The invulnerable save is 3+</description>
           <modifiers/>
         </rule>
       </rules>
@@ -3958,7 +3958,7 @@ Heat Blast (Fire Sweep): If the controlling player wishes, any unit the model pa
           <profiles>
             <profile id="b6b8-77f9-33f4-7b85" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Aura of Dark Glory" hidden="false">
               <characteristics>
-                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 5+ Invunerable save"/>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 5+ invulnerable save"/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -7294,7 +7294,7 @@ The Kharybdis is then placed as close to the initial landing location as safely 
       <modifiers/>
       <rules>
         <rule id="dd21-e827-ed40-3965" name="Caged Fury" hidden="false">
-          <description>When the bearer reaches 0 wounds or is removed as a casualty, you may Summon a Bloodthister of Unfettered Fury within 6&quot; of it before removing the model. At the end of the Controlling players turn, the Bloodthirster loses D3 wounds automatically, with only Invunerable saves allowed against these wounds.</description>
+          <description>When the bearer reaches 0 wounds or is removed as a casualty, you may Summon a Bloodthister of Unfettered Fury within 6&quot; of it before removing the model. At the end of the Controlling players turn, the Bloodthirster loses D3 wounds automatically, with only invulnerable saves allowed against these wounds.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -8125,7 +8125,7 @@ D3 / Mutation
       <profiles>
         <profile id="e086-af15-bc47-a877" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Sigil of Corruption" hidden="false">
           <characteristics>
-            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 4+ Invunerable save."/>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 4+ invulnerable save."/>
           </characteristics>
           <modifiers/>
         </profile>
@@ -9879,7 +9879,7 @@ If a model with this special rule charges a building or vehicle, the hit is reso
       <modifiers/>
     </rule>
     <rule id="9f39-46bc-1434-3391" name="Hellfire Reactor" hidden="false" page="0">
-      <description>Gains a 4+ Invunerable against any glance, and a 6+ Invunerable against any Penetration hit against it.
+      <description>Gains a 4+ invulnerable against any glance, and a 6+ invulnerable against any Penetration hit against it.
 In close combat, any psyker in combat with a contemptor suffers an automatic Str 2 AP 2 hit at the Initiative 10 step.
 
 If a Chaos Contemptor suffers an explosion result, add +D3 to the explosion radius and treat the explosion as if it has Soul Blaze.</description>
@@ -10259,7 +10259,7 @@ A model that made a Vector Strike in its Movement phase counts as having already
     </profile>
     <profile id="6e09-f2cd-d5e6-f5d7" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Ion Shield" hidden="false">
       <characteristics>
-        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="At the start of the opponents shooting phase, select the facing of the Ion Shield. The Ion Shield confers a 4+ Invunerable save against that facing until the start of your opponents next shooting phase."/>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="At the start of the opponents shooting phase, select the facing of the Ion Shield. The Ion Shield confers a 4+ invulnerable save against that facing until the start of your opponents next shooting phase."/>
       </characteristics>
       <modifiers/>
     </profile>
@@ -10475,7 +10475,7 @@ A model that made a Vector Strike in its Movement phase counts as having already
     </profile>
     <profile id="c5a0-ed39-5b4f-45e1" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Terminator Armour" hidden="false">
       <characteristics>
-        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 2+ Armour and 5+ Invunerable save. Also confers Bulky, Deep Strike and Relentless. Models may not make Sweeping Advances."/>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 2+ Armour and 5+ invulnerable save. Also confers Bulky, Deep Strike and Relentless. Models may not make Sweeping Advances."/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
While looking around about how to fix #2257 I noticed that Invulnerable was spelled incorrectly in the KDK data files. This pull request addresses that.
