### PR TITLE
Crozius re-fix and Relic fixes

### DIFF
--- a/Space Marines - Codex (2015).cat
+++ b/Space Marines - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7ab0-ceb9-0a9f-f0b6" revision="69" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Marines: Codex (2015)" books="" authorName="Earl Bishop (Kohato)" authorContact="iam@earlb3.com" authorUrl="https://github.com/BSData/wh40k/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7ab0-ceb9-0a9f-f0b6" revision="72" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Marines: Codex (2015)" books="" authorName="Earl Bishop (Kohato)" authorContact="iam@earlb3.com" authorUrl="https://github.com/BSData/wh40k/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="320d-148f-008f-f2a4" name="&quot;1st Company Veterans" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="40k Apocalypse">
       <entries/>
@@ -39119,18 +39119,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
           <entries>
             <entry id="f5d2-668e-9c1c-1947" name="Power Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
-                <entry id="7ac2-ddcd-5d39-ac12" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="30f5-5f80-fead-473f" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
                 <entry id="6aae-3408-8fac-24ed" name="The Panoply of the Crusader" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
                   <entryGroups/>
@@ -39319,6 +39307,29 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     </link>
                   </links>
                 </entryGroup>
+                <entryGroup id="f557-1b93-be1f-c00f" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="c48e-d50c-a602-0a41" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="8f4b-898d-1f89-f10f" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links>
+                    <link id="cfd9-cacb-cdce-7130" targetId="3ad6-0c48-5373-4635" linkType="entry">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entryGroup>
               </entryGroups>
               <modifiers/>
               <rules/>
@@ -39358,20 +39369,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
               </links>
             </entry>
             <entry id="1eec-0b95-56ea-ba10" name="Terminator Armour" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="d5d5-2b06-5a85-3b04" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="9c09-ea65-a342-6674" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
+              <entries/>
               <entryGroups>
                 <entryGroup id="65c4-95dd-f4f4-0367" name="Ranged Weapon" defaultEntryId="3100-335b-e7b8-7c78" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
@@ -39493,6 +39491,29 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     </link>
                   </links>
                 </entryGroup>
+                <entryGroup id="65e7-2395-7335-fa8b" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="d38b-9bbb-4318-f6b3" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="848e-bf6c-f534-5b02" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links>
+                    <link id="0015-321b-4321-09d9" targetId="3ad6-0c48-5373-4635" linkType="entry">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entryGroup>
               </entryGroups>
               <modifiers/>
               <rules/>
@@ -39516,20 +39537,7 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
               <links/>
             </entry>
             <entry id="5bab-c9dd-325c-0499" name="The Armour Indomitus" points="60.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="84cc-c661-27a6-a809" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="28d8-6517-16c0-9b49" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
+              <entries/>
               <entryGroups>
                 <entryGroup id="163b-b624-ae55-849a" name="Special Issue Wargear" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
@@ -39615,40 +39623,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                       <profiles/>
                       <links/>
                     </entry>
-                    <entry id="af86-9b40-3283-65b0" name="Wrath of the Heavens" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Kauyon">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers>
-                        <modifier type="decrement" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                          <conditions/>
-                          <conditionGroups>
-                            <conditionGroup type="or">
-                              <conditions>
-                                <condition parentId="163b-b624-ae55-849a" childId="1a84-aa16-5d40-07fc" field="selections" type="equal to" value="1.0"/>
-                                <condition parentId="163b-b624-ae55-849a" childId="76f6-549a-2530-06ff" field="selections" type="equal to" value="1.0"/>
-                              </conditions>
-                              <conditionGroups/>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </modifier>
-                        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                          <conditions>
-                            <condition parentId="force type" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="equal to" value="1.0"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <rules/>
-                      <profiles>
-                        <profile id="6890-c2ca-26ab-a89b" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Wrath of the Heavens" hidden="false">
-                          <characteristics>
-                            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value=""/>
-                          </characteristics>
-                          <modifiers/>
-                        </profile>
-                      </profiles>
-                      <links/>
-                    </entry>
                   </entries>
                   <entryGroups/>
                   <modifiers/>
@@ -39692,15 +39666,24 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
                     </link>
                   </links>
                 </entryGroup>
-                <entryGroup id="07bc-fda7-a06f-a54b" name="Chapter Specific Wargear Relics" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
+                <entryGroup id="ffe6-f338-4788-5a4b" name="Melee Weapon" defaultEntryId="91e7-d1d9-9dff-732d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="91e7-d1d9-9dff-732d" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="4437-729c-cf69-5d17" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
                   <entryGroups/>
                   <modifiers/>
-                  <links>
-                    <link id="4bfc-590c-d1ab-f392" targetId="b14b-2040-f3e1-f83c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
+                  <links/>
                 </entryGroup>
               </entryGroups>
               <modifiers/>
@@ -39745,14 +39728,14 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
             </entry>
             <entry id="19cb-d724-eb89-ea82" name="Armour of Shadows" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Kauyon">
               <entries>
-                <entry id="db0f-73e4-c396-4432" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entry id="ec5c-dbd9-a4c0-63d2" name="Crozius Arcanum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
                   <rules/>
                   <profiles/>
                   <links>
-                    <link id="6d82-7366-8bc6-a5c9" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
+                    <link id="54b2-55c8-6481-1090" targetId="e2507e57-2fb1-dfca-2781-fa09138bed14" linkType="profile">
                       <modifiers/>
                     </link>
                   </links>
@@ -50483,6 +50466,41 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
         </link>
       </links>
     </entry>
+    <entry id="3ad6-0c48-5373-4635" name="The Angel of Sacrifice" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers>
+        <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition parentId="force type" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="1915-aafd-da60-1098" name="Only in Death" hidden="false">
+          <description>If the bearer of the Angel of Sacrifice loses his last Wound in the Assault Phase, he is not removed as a casualty until after all close combat attacks have been resolved and can thus still attack if he is slain either by Overwatch or by a close combat attack made at a higher Initiative step.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="6ae1-96ed-2e92-089e" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Angel of Sacrifice" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+2"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Only in Death"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
     <entry id="6877-c655-cfa4-c106" name="The Emperor&apos;s Champion" points="140.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
       <entries>
         <entry id="8e2e-0c51-5cc4-3264" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -52300,7 +52318,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52327,7 +52345,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52354,7 +52372,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52381,7 +52399,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52408,7 +52426,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52435,7 +52453,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52462,7 +52480,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52489,7 +52507,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52516,7 +52534,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52543,7 +52561,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52570,7 +52588,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52597,7 +52615,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52624,7 +52642,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52727,7 +52745,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52757,7 +52775,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1f9f0258-eaff-588d-8cd1-993698c7d62d" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52792,7 +52810,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52813,71 +52831,6 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
           </profiles>
           <links/>
         </entry>
-        <entry id="dd84-98f5-a4da-4235" name="The Angel of Sacrifice (Chaplain Only)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition parentId="force type" childId="e587907b-cbac-80cd-d83d-1d007376c2fb" field="selections" type="less than" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <rules>
-            <rule id="9f5c-7752-d1a9-3212" name="Only in Death" hidden="false">
-              <description>If the bearer of the Angel of Sacrifice loses his last Wound in the Assault phase, he is not removed as a casualty until after all close combat attacks have been resolved, and can thus still attack if he is slain either by Overwatch or by a close combat attack made at a higher Initiative step</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles>
-            <profile id="8a6a-da48-0e61-9de4" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Angel of Sacrifice" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+2"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Only in Death"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="19ed-5303-1a11-ea7d" name="The Mindforge Stave" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition parentId="roster" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles>
-            <profile id="d2cc-1538-5bc7-c73d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Mindforge Stave" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
-                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="x2"/>
-                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
-                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Force, Unwieldy"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
         <entry id="0165-9efa-bca6-874f" name="Betrayer&apos;s Bane" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -52887,7 +52840,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52926,7 +52879,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52961,7 +52914,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -52996,7 +52949,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="e79008dd-b65e-28fa-7a70-fa2097475682" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -53026,7 +52979,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -53056,7 +53009,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -53091,7 +53044,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition parentId="roster" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
+                    <condition parentId="force type" childId="ba487d62-d836-cd64-642f-29e7abb8e86b" field="selections" type="less than" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -53841,6 +53794,36 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
               <modifiers/>
             </link>
           </links>
+        </entry>
+        <entry id="e3e8-a728-213a-003e" name="RELIC: The Mindforge Stave" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="force type" childId="1797915c-33bd-62cc-b1d6-ca469a9a9c31" field="selections" type="less than" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules/>
+          <profiles>
+            <profile id="e183-fe77-6f73-2420" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="RELIC: The Mindforge Stave" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value=""/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="x2"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Force, Unwieldy"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
         </entry>
       </entries>
       <entryGroups/>


### PR DESCRIPTION
Re-arranged Crozius fix to make it less dirty.  The relic is it's own shared entry and the chaplain now has a choice of crozius or that relic instead of placing it in an entry group of its own.

Also made relics tied to chapter tactics by force not roster - as it should be

@Salrantol - check out this commit if you want to see what I did for the crozius.

Closes #2273
