### PR TITLE
Multiple bugfixes for C:SM

### DIFF
--- a/Space Marines - Codex (2015).cat
+++ b/Space Marines - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7ab0-ceb9-0a9f-f0b6" revision="75" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Marines: Codex (2015)" books="" authorName="Earl Bishop (Kohato)" authorContact="iam@earlb3.com" authorUrl="https://github.com/BSData/wh40k/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7ab0-ceb9-0a9f-f0b6" revision="76" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Marines: Codex (2015)" books="" authorName="Earl Bishop (Kohato)" authorContact="iam@earlb3.com" authorUrl="https://github.com/BSData/wh40k/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="320d-148f-008f-f2a4" name="&quot;1st Company Veterans" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="40k Apocalypse">
       <entries/>
@@ -3551,7 +3551,11 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
                                   </entries>
                                   <entryGroups/>
                                   <modifiers/>
-                                  <links/>
+                                  <links>
+                                    <link id="6c04-c711-12b0-2537" targetId="ada0-29ba-d082-bf17" linkType="entry group">
+                                      <modifiers/>
+                                    </link>
+                                  </links>
                                 </entryGroup>
                                 <entryGroup id="de82-0fca-b0e8-9c4e" name="Storm Bolter Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                                   <entries>
@@ -3630,7 +3634,11 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
                                   </entries>
                                   <entryGroups/>
                                   <modifiers/>
-                                  <links/>
+                                  <links>
+                                    <link id="1a2f-044c-ca89-fede" targetId="ada0-29ba-d082-bf17" linkType="entry group">
+                                      <modifiers/>
+                                    </link>
+                                  </links>
                                 </entryGroup>
                                 <entryGroup id="b31c-7105-493e-d6fe" name="Special Issue Wargear" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                                   <entries>
@@ -3757,7 +3765,7 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
             </link>
           </links>
         </entryGroup>
-        <entryGroup id="99c1-35be-69c0-1fb9" name="Terminator Squad" defaultEntryId="753b-b834-a978-9cb5" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="99c1-35be-69c0-1fb9" name="Terminator Squad" defaultEntryId="753b-b834-a978-9cb5" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="753b-b834-a978-9cb5" name="Terminator Squad" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
@@ -3955,6 +3963,10 @@ Nominate any point over which the Stormraven moved that turn and deploy the squa
         <link id="02d1-0a55-1cf4-e023" targetId="2f8c-695e-b2c4-98de" linkType="entry">
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -22816,6 +22828,794 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
         </link>
       </links>
     </entry>
+    <entry id="ae9b-bedd-1135-e6a5" name="&apos;Strike Force Ultra *" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="48e6-883e-20ff-75a9" name="Venerable Dreadnought" points="125.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="476f-a032-7105-e815" name="Extra Armour" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="eba1-011e-0c6a-29f4" targetId="fcd538df-29d4-d39a-d1bd-f89dc0a34e57" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="5727-7aee-47ad-2f72" name="Left Arm Weapons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="b399-a6f2-40be-c962" name="Power Fist" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups>
+                    <entryGroup id="c1a5-72e8-a448-09e3" name="built-in weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries>
+                        <entry id="501f-04df-4056-e4d0" name="Storm Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="6e60-fd7e-1979-65e3" targetId="1fa19a43-d532-0ff4-7acd-642e4350b585" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="e576-960a-d468-b53e" name="Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="7b9a-9d65-c046-36aa" targetId="5bf5aacd-fcde-71dc-4151-5430b85d328a" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                      </entries>
+                      <entryGroups/>
+                      <modifiers/>
+                      <links/>
+                    </entryGroup>
+                  </entryGroups>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="0d44-2998-a6b7-6076" targetId="2e530344-9629-f19b-03cd-e9627187a635" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="a141-d45f-9354-c0b2" name="Missle Launcher" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="41be-4f1a-ee02-daf4" targetId="13b7bd3a-4e46-6cde-d3a6-56f317e444f3" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="bd6d-ef6b-c792-a9d8" targetId="dd83a2f3-4195-4c48-7408-be29913322c3" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="221f-d828-e7cd-36c7" name="Twin-linked Autocannon" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="1799-8467-ac79-c3c3" targetId="e2d3e5e2-de81-804c-7e43-396a4dfd1b34" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+            <entryGroup id="8623-9224-d362-cf1c" name="Right Arm Weapons" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="a30d-b230-eb6d-eb81" name="Multi-melta" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="85a6-f976-0313-28a0" targetId="7fb7ceb9-3505-265c-55e6-77e241ee54bc" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links>
+                <link id="6c1d-76b0-b2e6-059b" targetId="ed92-144b-96e7-403a" linkType="entry group">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="709d-cdb4-6234-8ef6" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Venerable Dreadnought" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+                <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="12"/>
+                <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+                <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+                <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="6723-b875-776e-11fc" targetId="15f12b40-90ae-a6cf-a89c-637f09456817" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="3302-1c81-7f49-6fe1" targetId="b2b9d48b-7476-c812-d0c9-621c3c072d46" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="0b6d-f3b9-79a2-8f6a" targetId="f0e6246d-137e-7921-4209-99318a073b42" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="c774-8f26-c355-34f1" targetId="2e1d45e6-2325-e88c-32a2-a8b4a76fe5e3" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="7f72-d4f5-2db4-ea8a" name="Terminator Assault Squad" points="0.0" categoryId="(No Category)" type="unit" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="2a97-851a-005f-e4bb" name="Any model may replace its two Lightning Claws for a Thunderhammer and Storm Shield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="9f0f-6d6d-f625-8089" targetId="658fd15b-771f-375a-d3fb-87367b9c46b0" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="b881-cc10-ea83-24ff" targetId="d2be9ef8-cf0c-44a8-1ab6-37d1e302dabc" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="cfa8-1843-60b7-d1fc" name="Terminator" points="35.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="fcba-943a-602d-4f3f" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Terminator" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="695b-990f-39ca-de87" name="Terminator Sergeant" points="35.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups>
+                <entryGroup id="c49e-95cc-9f5d-29a3" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="77ac-7703-57a5-465f" name="Two Lightning Claws" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="b320-3b03-a6fe-7e34" targetId="3381db5e-5f67-d4db-eace-7aaac6801e0b" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="b75c-1a0c-f45b-bab8" name="Thunderhammer and Storm Shield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="ac4b-0827-0cbe-3ac8" targetId="658fd15b-771f-375a-d3fb-87367b9c46b0" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="024f-b98f-ca56-7aad" targetId="d2be9ef8-cf0c-44a8-1ab6-37d1e302dabc" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="2df9-695f-80f0-fc2d" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Terminator Sergeant" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="cda6-bea6-ecad-1642" targetId="b0a75006-da49-ae36-212f-9059c11f2821" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="128e-8438-1362-e75f" targetId="6ee86cdb-44ec-741f-32f4-3fbe935807cf" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="f985-d5f8-81d4-757b" targetId="3381db5e-5f67-d4db-eace-7aaac6801e0b" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="49cc-a949-0d2d-7beb" name="Captain" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="f520-8f95-1c53-2db6" name="Captain" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups>
+                <entryGroup id="cafb-8855-dced-9abb" name="Commander" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="2503-1573-6a7a-83b9" name="Captain" points="90.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups>
+                        <entryGroup id="62fa-57b8-23ef-54f7" name="Armour" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                          <entries>
+                            <entry id="8cbe-3379-5b62-152b" name="Terminator Armour" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                              <entries/>
+                              <entryGroups>
+                                <entryGroup id="07fa-b631-6c34-36b2" name="Power Sword Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                  <entries>
+                                    <entry id="f858-a624-a49c-0866" name="Power Sword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="0bf9-2c29-7060-a98b" targetId="71581f2d-4a4a-89b9-ea95-7cedc042efbc" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="4538-6740-c950-cdd6" name="Thunder Hammer" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="de3a-d81c-27ed-bb87" targetId="d2be9ef8-cf0c-44a8-1ab6-37d1e302dabc" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="f575-7a4d-60d4-f254" name="Lightning Claw" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="0b4a-ffd2-fb49-0eba" targetId="3381db5e-5f67-d4db-eace-7aaac6801e0b" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="eba9-8c66-5fdb-3e32" name="Storm Shield" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="d261-f668-9ca4-f692" targetId="658fd15b-771f-375a-d3fb-87367b9c46b0" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="08b4-95e8-94d2-60eb" name="Power Fist" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="f61a-057c-0399-cfd9" targetId="2e530344-9629-f19b-03cd-e9627187a635" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="682d-8e1b-5d0e-b5a1" name="Chainfist" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="65e3-cded-f30a-70b1" targetId="43d8d9ec-8695-aa55-3250-4e13f05cec93" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                  </entries>
+                                  <entryGroups/>
+                                  <modifiers/>
+                                  <links>
+                                    <link id="2344-2b9c-d5d0-40ed" targetId="ada0-29ba-d082-bf17" linkType="entry group">
+                                      <modifiers/>
+                                    </link>
+                                  </links>
+                                </entryGroup>
+                                <entryGroup id="fc97-e2f8-41bb-2635" name="Storm Bolter Arm" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                  <entries>
+                                    <entry id="d56c-9e51-7159-e498" name="Storm Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="d81c-38b9-d79c-1578" targetId="1fa19a43-d532-0ff4-7acd-642e4350b585" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="9912-2a1d-e588-ea48" name="Combi-flamer" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="bd05-5d42-f2c5-fe04" targetId="7f0ef365-2854-6510-8ad1-68ef91094599" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="d61d-8ba8-deb5-7249" name="Combi-melta" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="908f-59e0-d096-4c28" targetId="58709045-42b9-6a17-2203-ffe8b82cb796" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="0725-1ae8-bed0-07df" name="Combi-plasma" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="3274-883d-4878-219e" targetId="f3bbe6fc-8a95-5407-17fc-4ddaa9ce62d8" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="8d7a-b143-f5ea-98da" name="Lightning Claw" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="e766-9d6d-3f3e-7b6b" targetId="3381db5e-5f67-d4db-eace-7aaac6801e0b" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="c771-7370-2ebe-5261" name="Thunder Hammer" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="143d-ab1f-1b15-e3fb" targetId="d2be9ef8-cf0c-44a8-1ab6-37d1e302dabc" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                  </entries>
+                                  <entryGroups/>
+                                  <modifiers/>
+                                  <links>
+                                    <link id="dfa8-c180-9ed7-7118" targetId="ada0-29ba-d082-bf17" linkType="entry group">
+                                      <modifiers/>
+                                    </link>
+                                  </links>
+                                </entryGroup>
+                                <entryGroup id="411e-dd7e-8985-30d3" name="Special Issue Wargear" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                  <entries>
+                                    <entry id="3713-b9a0-4764-e722" name="Auspex" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="3b26-4a78-fa04-a371" targetId="37591ce3-75cb-04e3-fbf3-b24c277514e0" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="df18-ec8f-d8e1-d6ae" name="Melta Bombs" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="b267-3d7c-28f9-651a" targetId="7154132f-7a1a-aa55-0d4f-78fa4d2c7b91" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="540e-1ccb-3922-43f3" name="Teleport Homer" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="e13d-08df-f855-bdbc" targetId="8f662d2c-803f-f4f0-1e78-a33d0b380244" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                    <entry id="8bd5-23f6-6068-0de6" name="Digital Weapons" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                                      <entries/>
+                                      <entryGroups/>
+                                      <modifiers/>
+                                      <rules/>
+                                      <profiles/>
+                                      <links>
+                                        <link id="a140-8c7e-9c0b-9629" targetId="b43dc580-1947-00a2-3d67-03bde443112b" linkType="profile">
+                                          <modifiers/>
+                                        </link>
+                                      </links>
+                                    </entry>
+                                  </entries>
+                                  <entryGroups/>
+                                  <modifiers/>
+                                  <links/>
+                                </entryGroup>
+                              </entryGroups>
+                              <modifiers/>
+                              <rules/>
+                              <profiles>
+                                <profile id="7772-63fd-5f87-3103" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Captain" hidden="false">
+                                  <characteristics>
+                                    <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                                    <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+                                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                                    <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                                    <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                                    <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                                    <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                                    <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                                    <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+                                    <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
+                                  </characteristics>
+                                  <modifiers/>
+                                </profile>
+                              </profiles>
+                              <links/>
+                            </entry>
+                          </entries>
+                          <entryGroups/>
+                          <modifiers/>
+                          <links/>
+                        </entryGroup>
+                      </entryGroups>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links/>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links>
+                    <link id="d16c-4f49-d20d-ce42" targetId="81b16515-0b7f-791d-7bbd-da8deab0fc2f" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="49cb-7bf1-e654-93eb" targetId="3830-b063-69aa-2582" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="183b-3fcd-76a8-afe5" name="Land Raider Transport" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="3101-52b0-8ecb-21c3" targetId="b399-2dc7-ed23-83a3" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="dbbd-edf7-474c-4fa7" targetId="117a-4b0a-60c7-c882" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="b301-ebbb-86b9-c28a" name="Terminator Squad" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="c101-568b-0f2c-fcbc" name="Terminator Squad" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="893e-e4e4-eed7-d5ce" name="Terminator" points="35.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles>
+                    <profile id="234e-271a-ca45-f993" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Terminator" hidden="false">
+                      <characteristics>
+                        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+                        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links/>
+                </entry>
+                <entry id="aac2-edb4-6b8e-3081" name="Terminator Sergeant" points="35.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="baff-b77d-84a4-96f6" name="Power Sword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="2ef3-039f-f0ec-42d3" targetId="71581f2d-4a4a-89b9-ea95-7cedc042efbc" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="1b02-d407-dd0f-73d0" name="Storm Bolter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="d6c4-c07a-c873-f749" targetId="1fa19a43-d532-0ff4-7acd-642e4350b585" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles>
+                    <profile id="c351-da01-1b62-13d0" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Terminator Sergeant" hidden="false">
+                      <characteristics>
+                        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+                        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links/>
+                </entry>
+                <entry id="5531-92c9-2cce-1085" name="May replace Power Fist with Chainfist" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="45e0-9622-bc3f-379e" targetId="43d8d9ec-8695-aa55-3250-4e13f05cec93" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups>
+                <entryGroup id="e33b-49d0-9c92-4769" name="For every five models one Terminator may choose one of the following" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="62d9-cb1b-2ce8-6151" name="Cyclone Missle Launcher" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="46be-f977-3295-2f91" targetId="15da862d-b310-a825-dbed-f21cc783458e" linkType="profile">
+                          <modifiers/>
+                        </link>
+                        <link id="1025-445e-3361-b852" targetId="42591aaf-5565-9227-c070-a2782efaedbb" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="36e0-dc7f-e78f-f44c" name="Replace Storm Bolter with Assault Cannon" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="178f-dfb4-282c-0fed" targetId="d63e0147-bdf8-13d4-d9a7-5568dc998a65" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="f3f3-8590-9dff-5492" name="Replace Storm Bolter with Heavy Flamer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="5610-0667-b843-2c31" targetId="5bf5aacd-fcde-71dc-4151-5430b85d328a" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="fbf3-620d-3e8e-e099" targetId="b0a75006-da49-ae36-212f-9059c11f2821" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="ae04-a4f0-5f24-80e4" targetId="1fa19a43-d532-0ff4-7acd-642e4350b585" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="001c-4bda-f869-600d" targetId="2e530344-9629-f19b-03cd-e9627187a635" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="6d5d-ce77-2a0b-8e9e" targetId="6ee86cdb-44ec-741f-32f4-3fbe935807cf" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a329-a95a-ee4f-7410" targetId="1f8e-34f5-8cd9-f814" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers>
+        <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition parentId="force type" childId="9706-acb7-53b0-3761" field="selections" type="instance of" value="0.0"/>
+                <condition parentId="force type" childId="de22-54d3-049b-e814" field="selections" type="instance of" value="0.0"/>
+                <condition parentId="force type" childId="9e5a-933c-f94f-964c" field="selections" type="instance of" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="4015-dfb0-9eb1-b26d" name="Ultra Strike" hidden="false">
+          <description>As long as this Formation&apos;s Terminator Captain is still alive, the controlling player makes Reserve Rolls for any of this Formation&apos;s units from his first turn.</description>
+          <modifiers/>
+        </rule>
+        <rule id="133d-656d-364c-fc75" name="Fury of the Storm" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="c672-22bf-d12f-b479" name="Force of a Thunderbolt" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="4590-db28-1759-83f1" targetId="2f8c-695e-b2c4-98de" linkType="entry">
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
   </entries>
   <rules/>
   <links>
@@ -23108,9 +23908,6 @@ The Warlord Titan&apos;s carapace-mounted weapons may not target models closer t
       <modifiers/>
     </link>
     <link id="cb73-2dae-a243-b44b" targetId="106e-c950-e596-acf2" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
-      <modifiers/>
-    </link>
-    <link id="abf6-a6d1-df54-cace" targetId="1bf9-63ec-2460-50ed" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
       <modifiers/>
     </link>
     <link id="a857-3f69-01ab-0e5f" targetId="2034-3a83-a7e2-9ad3" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
@@ -37795,6 +38592,19 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                     </link>
                   </links>
                 </entryGroup>
+                <entryGroup id="8dd9-ac3a-cdd9-a29b" name="Melee Weapon" defaultEntryId="7552-ab89-dd5a-fb29" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links>
+                    <link id="7552-ab89-dd5a-fb29" targetId="6461-eb05-9a63-e283" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                    <link id="7a49-6782-7d34-8bd2" targetId="ada0-29ba-d082-bf17" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entryGroup>
               </entryGroups>
               <modifiers/>
               <rules/>
@@ -37825,9 +38635,6 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                 </profile>
               </profiles>
               <links>
-                <link id="7a1d-9cb0-de8b-e9f3" targetId="6461-eb05-9a63-e283" linkType="entry group">
-                  <modifiers/>
-                </link>
                 <link id="2aa9-701d-36df-f3fd" targetId="333bca0d-9f8c-7716-6d71-9c2a5ffc501c" linkType="profile">
                   <modifiers/>
                 </link>
@@ -37975,6 +38782,19 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                     </link>
                   </links>
                 </entryGroup>
+                <entryGroup id="8a6c-557c-713d-56d9" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <links>
+                    <link id="a5bd-0efa-1154-8211" targetId="6461-eb05-9a63-e283" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                    <link id="3806-52cc-2026-397c" targetId="ada0-29ba-d082-bf17" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entryGroup>
               </entryGroups>
               <modifiers/>
               <rules/>
@@ -38000,11 +38820,7 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                   </modifiers>
                 </profile>
               </profiles>
-              <links>
-                <link id="563d-d3c6-ac08-6698" targetId="6461-eb05-9a63-e283" linkType="entry group">
-                  <modifiers/>
-                </link>
-              </links>
+              <links/>
             </entry>
             <entry id="a533-5af8-a543-7487" name="The Armour Indomitus" points="60.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
@@ -38028,9 +38844,6 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                   <modifiers/>
                   <links>
                     <link id="673b-5d20-487a-e13b" targetId="73aa-7a3f-cc29-d541" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                    <link id="8c0a-7fd7-3667-ccf9" targetId="ada0-29ba-d082-bf17" linkType="entry group">
                       <modifiers/>
                     </link>
                   </links>
@@ -38158,12 +38971,12 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="89b7-424f-3c9f-8d1a" name="Chapter Specific Wargear Relics" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="5a05-1ad1-dd4b-dfd6" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
                   <links>
-                    <link id="01aa-6f9f-e183-44f0" targetId="b14b-2040-f3e1-f83c" linkType="entry group">
+                    <link id="f603-6ef0-a1ec-ad32" targetId="6461-eb05-9a63-e283" linkType="entry group">
                       <modifiers/>
                     </link>
                   </links>
@@ -38202,9 +39015,6 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                 </profile>
               </profiles>
               <links>
-                <link id="7894-689c-0123-af53" targetId="6461-eb05-9a63-e283" linkType="entry group">
-                  <modifiers/>
-                </link>
                 <link id="0d0b-8425-2b1c-4dc8" targetId="333bca0d-9f8c-7716-6d71-9c2a5ffc501c" linkType="profile">
                   <modifiers/>
                 </link>
@@ -38321,16 +39131,6 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                   <modifiers/>
                   <links/>
                 </entryGroup>
-                <entryGroup id="945b-20fb-e07f-b02d" name="Chapter Specific Wargear Relics" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="cef9-7bb1-a172-e58d" targetId="b14b-2040-f3e1-f83c" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
                 <entryGroup id="ae54-0799-6ddd-0596" name="Ranged Weapon" defaultEntryId="1ce1-2e5d-dcc9-2b1f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries>
                     <entry id="1ce1-2e5d-dcc9-2b1f" name="Bolt Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -38350,9 +39150,6 @@ In addition, if Kor&apos;sarro Khan slays the enemy Warlord in a challenge, you 
                   <modifiers/>
                   <links>
                     <link id="6ca2-69b9-996b-abc2" targetId="73aa-7a3f-cc29-d541" linkType="entry group">
-                      <modifiers/>
-                    </link>
-                    <link id="5c1d-a2ad-95a3-b106" targetId="ada0-29ba-d082-bf17" linkType="entry group">
                       <modifiers/>
                     </link>
                   </links>
@@ -41923,48 +42720,6 @@ All powers must be selected from the same discipline before the beginning of the
           <modifiers/>
         </link>
         <link id="6e1a-8a91-65d0-f860" targetId="a7b704ae-416e-da95-9cf7-478a7e46bfe0" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1bf9-63ec-2460-50ed" name="Storm Wing" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Death from the Skies" page="113">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="de41-664a-ea33-64c6" name="Stormraven" defaultEntryId="211b-995d-6314-bf6b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="211b-995d-6314-bf6b" targetId="2f8c-695e-b2c4-98de" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="465f-18ca-0987-d5e6" name="Stormtalons" defaultEntryId="2ad6-e199-280a-dd5e" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2ad6-e199-280a-dd5e" targetId="fb10-3438-8efe-363a" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="32b5-6609-dddf-148c" name="Data Lattice" hidden="false" book="Death from the Skies" page="113">
-          <description>The Formation’s Stormraven Gunship has the Strafing Run special rule if the Wing is in an Attack Pattern.</description>
-          <modifiers/>
-        </rule>
-        <rule id="08da-3149-6437-f8e9" name="Orbital Power Dive" hidden="false" book="Death from the Skies" page="113">
-          <description>Add 12&quot; to the minimum and maximum moves of all models in the Formation in the Movement phase that they first arrive from Reserve. In addition, enemy models that use the Interceptor special rule to attack models from this formation on the turn that they first arrive from Reserve can only take Snap Shots.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="d021-358b-5c96-dd25" targetId="0b1c-07c5-7c77-2920" linkType="rule">
           <modifiers/>
         </link>
       </links>


### PR DESCRIPTION
Fixed Strike Force Ultra missing in Formations

Added relics to Strike Force Ultra captain and fixed unit requirements

Fixed Librarian relics not showing on melee weapon.  Mindforge stave will be available (but named "Librarian Only") to all units until the re-write for 2.0 - to split it out requires a lot of hunting for entries that will not be necessary soon with 2.0

Deleted duplicate Storm Wing

Closes #2289
