### PR TITLE
Space Wolves - "Kingsguard (formation)" and Runic Weapon rule fixes

### DIFF
--- a/Space Wolves - Codex.cat
+++ b/Space Wolves - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="76" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="21e36b7e-84ee-2ec0-53f2-2c32fd8bd981" revision="77" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Space Wolves: Codex (2014)" books="" authorName="BSData" authorContact="" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="dec7-3100-06a0-9ae8" name="&quot;Deathpack&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Start Collecting! Space Wolves">
       <entries/>
@@ -38204,6 +38204,9 @@ Models in affected units add 1 to their Attack characteristic.</description>
             <link id="e74c2316-ea68-73c5-876f-8a1adf8fbe35" targetId="96f0f59a-7a00-6ed0-cbde-b243cb7fd14f" linkType="rule">
               <modifiers/>
             </link>
+            <link id="4218-393e-7641-3ee0" targetId="f9d2bc2a-a97d-d31a-6248-8c3e5bda2080" linkType="rule">
+              <modifiers/>
+            </link>
           </links>
         </entry>
         <entry id="d6093156-5327-6924-b78e-81d88b9ff13d" name="Rune Sword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -38219,6 +38222,9 @@ Models in affected units add 1 to their Attack characteristic.</description>
             <link id="4f885b60-13c6-7a08-8701-957e3cd894dc" targetId="96f0f59a-7a00-6ed0-cbde-b243cb7fd14f" linkType="rule">
               <modifiers/>
             </link>
+            <link id="c150-04b3-4ec8-3376" targetId="f9d2bc2a-a97d-d31a-6248-8c3e5bda2080" linkType="rule">
+              <modifiers/>
+            </link>
           </links>
         </entry>
         <entry id="69bf6a48-8dd3-be35-824e-7c13277d2906" name="Rune Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -38232,6 +38238,9 @@ Models in affected units add 1 to their Attack characteristic.</description>
               <modifiers/>
             </link>
             <link id="a2289251-4f16-7a3d-7453-ae11cc833032" targetId="96f0f59a-7a00-6ed0-cbde-b243cb7fd14f" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="76f9-77d1-93a3-7e7b" targetId="f9d2bc2a-a97d-d31a-6248-8c3e5bda2080" linkType="rule">
               <modifiers/>
             </link>
           </links>
@@ -43795,7 +43804,7 @@ Having Infiltrate also confers the Outflank special rule to units of Infiltrator
       <modifiers/>
     </rule>
     <rule id="1fca63c8-617f-5a94-544f-bd0ee6cc1cf6" name="Kingsguard (formation)" hidden="false" book="Champions of Fenris">
-      <description>The following Strike Force Daggerfist models have +1 Weapon Skill already included on profile:
+      <description>The following models in this Formation have +1 Weapon Skill already included on profile:
 
 - Wolf Guard
 - Wolf Guard Pack Leader
@@ -44389,7 +44398,8 @@ At the beginning of every subsequent player turn, the marker scatters 2D6&quot; 
       <description>Ragnar and all models with the Space Wolves Faction in his unit have the Furious Charge special rule.</description>
       <modifiers/>
     </rule>
-    <rule id="96f0f59a-7a00-6ed0-cbde-b243cb7fd14f" name="Ward" hidden="false" book="Codex: Space Wolves" page="52">
+    <rule id="96f0f59a-7a00-6ed0-cbde-b243cb7fd14f" name="Ward" hidden="false" book="Codex: Space Wolves" page="97">
+      <description>A model Equipped with this weapon has the Adamantium Will special rule.</description>
       <modifiers/>
     </rule>
     <rule id="d0738c1d-db35-3198-45a4-cbc753ead8fd" name="Ward of the Primarch" hidden="false" book="Codex: Space Wolves" page="57">


### PR DESCRIPTION
- Changed the rule text so that it's not specific to Strike Force Daggerfist, but can be used in other formations as well
- Added Adamantium Will to Runic weapons for Rune Priest
- Added Ward rule text and corrected page number
- Closes #2297 and #2298
