### PR TITLE
ReAdd Green Tide, fix Mek Close combat points cost.  Added Forgeworld DFtS Updates

### DIFF
--- a/Orks - Codex.cat
+++ b/Orks - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5e29cf46-0edb-4f2a-8b49-7691fba3e163" revision="60" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Orks: Codex (2014)" authorName="tag8833" authorContact="tag8833@yahoo.com" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5e29cf46-0edb-4f2a-8b49-7691fba3e163" revision="61" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Orks: Codex (2014)" authorName="tag8833" authorContact="tag8833@yahoo.com" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="13471a19-62d9-e7bc-9af9-6bce6b5d3935" name="&quot;Grukk&apos;s Rippin&apos; Krew&quot;" points="0.0" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Sanctus Reach: Stormclaw" page="29">
       <entries/>
@@ -3275,93 +3275,6 @@
         </link>
       </links>
     </entry>
-    <entry id="d6f0c7fe-1095-49fa-ef27-65aa1adb8569" name="Attak Fightas (FW)" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour - Aeronautica" page="42">
-      <entries>
-        <entry id="7acf62e0-fd47-e4bb-b3b6-3e08512ffddb" name="Attak Fighta" points="95.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
-          <entries>
-            <entry id="864736bf-d094-b303-7522-d22934ecf9f6" name="Twin-linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="29287839-8925-7ac1-dffa-d90b4b65acd0" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="39844801-800e-afe0-349a-58b6d51129c4" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5a382504-5e6d-5af6-a375-d9f00d647303" targetId="0659c2f0-2ade-4c75-631f-ff484780df39" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="6875ca1f-5eb5-57c0-2a9c-ccbe8de9504b" name="Must Choose 1" defaultEntryId="0ece0029-0b13-0c4e-9409-8f7e325c3fe2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-              <entries>
-                <entry id="0ece0029-0b13-0c4e-9409-8f7e325c3fe2" name="2x Bomms" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="0c2098cd-b1ee-674a-fd7e-ae01b11f6af2" targetId="ae0f5463-1c63-689b-7ebb-3a38556e75c4" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="91ebc00b-9438-64d8-860b-cf426ccac503" name="2x Rokkits" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="714dd385-79b3-3901-7874-0b45973c3b63" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="cd93d483-7c06-58ef-ae18-9257afb6bddf" targetId="381bb905-a0f2-f66b-13ee-74bbf271a5cf" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="59d9247a-770a-3636-bad5-bfb7d16ce229" targetId="90311584-d42b-5056-1554-0c859a6db9ab" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="31722afd-13e5-41ee-d783-023c6a99f348" targetId="8b2014ba-8549-779b-fde6-57272a8177a9" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="81a24308-f432-f3be-7eaf-8193e8b4382e" targetId="eb95dad9-5e29-2474-4d99-3874751f67c1" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
     <entry id="4c77f55c-29d6-0459-b0f6-1221a4b333c0" name="Badrukk&apos;s Flash Gitz" points="120.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Sanctus Reach: Heroes of Sanctus Reach" page="0">
       <entries>
         <entry id="374e5c4b-2715-64bd-1dee-47b4e7342190" name="Flash Git" points="0.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -4451,166 +4364,6 @@
           <modifiers/>
         </link>
         <link id="7d10-3875-2456-e875" targetId="a738-6823-ea7f-0494" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="65d257cb-abe5-ece9-3c2f-9aa16c7c6144" name="Fighta-Bommer (FW)" points="170.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour - Aeronautica" page="41">
-      <entries>
-        <entry id="2d811003-869c-4a76-b2c3-66134995849b" name="Twin-linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="bd49b89a-c71f-0aec-8055-30023249dcc3" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="341ff4ed-205a-d992-39d2-cf3d3413f1e3" name="Turret-mounted Twin-linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="b0742bd4-994d-e7ec-ef13-c7093ad4383a" targetId="6d5f6f18-bf6d-7687-3e84-c01fcaeb12d3" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="26467d65-86c6-6c1a-3f41-0d71003c0599" targetId="48916643-2f54-dfcd-f165-4d47d6afb04b" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="7326825d-2cb6-0201-ba1a-7d236fd937e1" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="2163e3ed-72af-9a1d-7e52-4d7fcd0acdf0" targetId="0659c2f0-2ade-4c75-631f-ff484780df39" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="8900f01f-9a62-b59a-3ab5-7c953de3ff95" name="Must Choose 6" defaultEntryId="69890fdf-0f78-b40c-0561-95c2fedf9b86" minSelections="6" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="7a563fc6-0c57-6328-ee6a-10a040f74a85" name="Bomm" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="f603860c-c702-357a-0ff7-d2ee83e58d17" targetId="ae0f5463-1c63-689b-7ebb-3a38556e75c4" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="69890fdf-0f78-b40c-0561-95c2fedf9b86" name="Rokkit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="d2cdb6a2-78e8-1c16-d66a-465070846d6e" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="4e69aade-9013-d3cd-a7d9-7626e30c7c11" name="Grot Bomm" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="f869102e-4041-c950-69e6-410dfba99b4a" targetId="d62f6cb7-1f98-2a5a-9e02-e3adf91ae3fa" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="acc7a727-88aa-d7f4-cd3c-920143044221" targetId="6df5fbe0-2c1e-43e1-72b3-21e0b001aae3" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="a41db40c-f850-c65b-72a6-a0e4df51e6e6" name="Or 1 (Apoc Only)" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="b352cb04-9439-e545-4a32-df45fc379ebb" name="Burna Bomms" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="da60a2b2-163c-d424-4958-be980c8c77da" targetId="fd0c63e9-e80a-65af-c813-7cd43f021bb6" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1aabade8-d75b-04df-b1ef-07a7320a8f8b" name="Apocalypse Bomms" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f88d9306-903f-5da5-0a84-5f7365135903" targetId="fd0c63e9-e80a-65af-c813-7cd43f021bb6" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="force type" childId="3bfe125e-5674-06d5-082f-f7f577ea26fc" field="selections" type="instance of" value="0.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="65d257cb-abe5-ece9-3c2f-9aa16c7c6144" childId="a41db40c-f850-c65b-72a6-a0e4df51e6e6" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="65d257cb-abe5-ece9-3c2f-9aa16c7c6144" childId="a41db40c-f850-c65b-72a6-a0e4df51e6e6" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="15b02574-4dff-e526-964a-e04f29279b2c" targetId="d6b536dd-36ae-1baf-53a7-df8fa5944191" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="6c167b0d-a17e-f29a-175c-e9933e7448e2" targetId="381bb905-a0f2-f66b-13ee-74bbf271a5cf" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d6f4f19c-f3e3-3941-8a0d-12a663c5ba1d" targetId="90311584-d42b-5056-1554-0c859a6db9ab" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="fd75fc51-9a04-42e8-cfb5-a638c425ee9b" targetId="eb95dad9-5e29-2474-4d99-3874751f67c1" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -8775,166 +8528,6 @@
         </link>
       </links>
     </entry>
-    <entry id="4fd705f1-c7d5-767a-fde5-ced5778dc1f9" name="Warkopta Skwadron (FW)" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dred_Mob.pdf" page="0">
-      <entries>
-        <entry id="33cbae8e-bf5d-1d2e-3c8f-e1ad3d6bbe79" name="Warkopta" points="65.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5e344cd3-bd4c-e9c1-37a4-9ce2a2d67ff6" name="May Take Any" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="09d50243-5593-b078-9150-4e000bd94df3" name="Stikkbomb Chukka" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="9476a437-8287-156d-9904-0376554ef2c6" targetId="e78e5295-6e2c-9389-56d9-cfe46b133003" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="906c0305-2b57-4ea2-1781-9f0c5fe3be04" name="Red Paint Job" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="d1485562-79ce-8f76-90b6-dd3ccc82a5e0" targetId="7bf40f92-7deb-b55d-e8e0-578efa16dc3d" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="e310d0d5-fa2d-a8cd-5100-13822af7d166" name="Bigbomm" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="45f2d9b2-78ed-8f90-c58c-b8467b0f70dc" targetId="c5e4c919-08f6-f38a-75a4-84ce0ddf51b5" linkType="profile">
-                      <modifiers/>
-                    </link>
-                    <link id="239c7947-dc93-1e03-4efe-e0f7f29085fd" targetId="c0019570-79d1-032a-21b2-a32e91b3882b" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="14b651df-b827-a683-79dd-4f160bc61f77" name="Must Take 1" defaultEntryId="0b959920-9171-36a8-9de3-ddd663ce1e69" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="0b959920-9171-36a8-9de3-ddd663ce1e69" name="Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f19c1cf3-21b3-2ff5-0acf-bf058e258fd0" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="92f32d82-7aa1-c27f-3bee-6411125e11dc" name="Skorcha" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="762fce3a-924c-e608-aa24-1ee9429a2987" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="04735531-32cd-4e5b-33de-cb58c5f14529" name="Rokkit Launcha" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="74dfa64b-1632-fb08-343e-a7904b51d916" targetId="076b7eee-123d-6d81-3099-053319f2ada6" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1369f411-cb4b-8979-78f2-0a742d90e623" name="Kustom Mega-blasta" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="96f358c5-8288-f72f-a845-8570a38719ba" targetId="40a0dc73-b56e-6e3c-2239-e1bb69f1c2fb" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="b1df08b8-b9ea-92fb-7df4-5b4bdac2589e" name="Must Take 1" defaultEntryId="c7bb3572-fda7-6780-e9f1-18453059b086" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="1500270f-ec23-f0c5-1fa3-c71feb26ae50" name="Twin-linked Rattler Kannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="0f208e55-421c-b6cb-ef13-cb67093e450f" targetId="30130129-53bf-fc38-6ebe-cd4a4d6c31f9" linkType="profile">
-                      <modifiers/>
-                    </link>
-                    <link id="2a8ee7e7-5331-fea3-c284-8e166c7035d3" targetId="469df92c-cf8a-7217-5827-4b5308be4d1f" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="c7bb3572-fda7-6780-e9f1-18453059b086" name="Twin-linked Deffgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="99267afb-91d3-901a-c5a1-003dec7cbf8d" targetId="569bd8eb-a569-4aff-e138-874d90968771" linkType="profile">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="d12a9f6d-3aea-39fb-933f-3d10c4a46a07" targetId="96f7edc0-4791-34b9-19fd-2632e268e867" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="5dcb-5350-acd3-ef6b" targetId="e5be-154b-56bf-f644" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
     <entry id="63e686d8-d3ed-8c85-003a-c503fdc00614" name="Zhadsnark&apos;s Warbikers" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="6" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Codex: Orks" page="0">
       <entries/>
       <entryGroups>
@@ -9650,6 +9243,30 @@
       <modifiers/>
     </link>
     <link id="1011-9e27-0dd4-a9f4" targetId="d2d3-9700-bf82-eafc" linkType="entry" categoryId="8c73-dac2-10f4-9b50">
+      <modifiers/>
+    </link>
+    <link id="d140-9d00-e1d1-09fa" targetId="465c-1336-3edf-ef25" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="ce72-0f73-e80f-2fe4" targetId="d8d0-0523-ea27-c3fc" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="f309-f6dd-6af4-0463" targetId="f29c-b880-0ae9-b1b8" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="bdbb-3059-3b0a-b235" targetId="f29c-b880-0ae9-b1b8" linkType="entry" categoryId="8c73-dac2-10f4-9b50">
+      <modifiers/>
+    </link>
+    <link id="f25a-39a0-8ce3-be12" targetId="a389-2e04-532e-fd4c" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="6f62-0722-0d31-61a6" targetId="1698-7849-444e-a126" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="bba5-3d2f-4098-dd66" targetId="02f5-4228-4450-3d67" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="910b-e59b-c6b7-8b86" targetId="02f5-4228-4450-3d67" linkType="entry" categoryId="8c73-dac2-10f4-9b50">
       <modifiers/>
     </link>
   </links>
@@ -16575,7 +16192,7 @@
                 <link id="7d8a-0e60-8e18-d601" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
                   <modifiers/>
                 </link>
-                <link id="4b19-8cd8-5a35-da74" targetId="afae-bdc8-d82b-e069" linkType="entry group">
+                <link id="4b19-8cd8-5a35-da74" targetId="fb41-3b79-e0eb-0343" linkType="entry group">
                   <modifiers/>
                 </link>
                 <link id="79bd-ba24-b19e-048f" targetId="380f-2bcb-11ac-8952" linkType="entry group">
@@ -19526,7 +19143,7 @@
                 <link id="b46930ac-d06f-9469-1acd-f84eb18a1389" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
                   <modifiers/>
                 </link>
-                <link id="2127-294b-1f49-8d16" targetId="afae-bdc8-d82b-e069" linkType="entry group">
+                <link id="2127-294b-1f49-8d16" targetId="fb41-3b79-e0eb-0343" linkType="entry group">
                   <modifiers/>
                 </link>
                 <link id="5a61-454b-7984-7c21" targetId="380f-2bcb-11ac-8952" linkType="entry group">
@@ -25281,6 +24898,853 @@
         </link>
       </links>
     </entry>
+    <entry id="465c-1336-3edf-ef25" name="&quot;Green Tide&quot;" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Waaagh! Ghazghkull (Old Version via GW FAQ)" page="59">
+      <entries>
+        <entry id="2482-d9be-1958-b6e3" name="Boyz" points="0.0" categoryId="(No Category)" type="unit" minSelections="10" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="9efd-e2df-ab50-2962" name="&apos;Eavy Armour for Mob" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="92cf-0920-3f74-2966" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="afb6-8f6b-a4b1-eb80" name="Mob" defaultEntryId="1520-3786-cce6-f4db" minSelections="10" maxSelections="30" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="2203-e846-1d85-f610" name="Boss Nob" points="16.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="d0ad-8319-f437-f755" name="Bosspole" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="db25-bd15-0e2e-f961" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="b115-1b66-7a3d-2e65" name="Stikkbombs" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="269b-4ab6-d05d-5198" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="ec69-0721-c176-d5e9" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" linkType="entry">
+                      <modifiers/>
+                    </link>
+                    <link id="6c23-edc1-f53f-c42a" targetId="7104-bd6b-9e73-e763" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                    <link id="0170-57f7-27e7-f2bd" targetId="8634-ccd3-df89-d499" linkType="entry group">
+                      <modifiers/>
+                    </link>
+                    <link id="1ec3-2f1d-d273-e0ed" targetId="47abc561-469a-0e41-00e8-5d9ea56484bc" linkType="profile">
+                      <modifiers>
+                        <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                          <conditions>
+                            <condition parentId="2482-d9be-1958-b6e3" childId="9efd-e2df-ab50-2962" field="selections" type="at least" value="1.0"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="1520-3786-cce6-f4db" name="Boy" points="6.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="30" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="d762-9993-a155-a3c1" name="Choppa" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="dea9-2a46-46ce-5e15" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="8a0a-8b2f-1dfd-ffa7" name="Stikkbombs" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="4957-d7e0-3bae-aa97" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" linkType="profile">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups>
+                    <entryGroup id="0485-9a7d-553f-f5df" name="Must Choose 1" defaultEntryId="a9ab-5cb2-cf5a-c5b7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries>
+                        <entry id="a9ab-5cb2-cf5a-c5b7" name="Slugga" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="b844-0cff-dea6-a9ef" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="c115-f08f-9911-1619" name="Shoota" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="32c8-25b1-4fb8-6173" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                      </entries>
+                      <entryGroups/>
+                      <modifiers/>
+                      <links/>
+                    </entryGroup>
+                  </entryGroups>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="1581-5e46-f922-afa3" targetId="eb659805-d021-ab73-c776-3017ac5c3d26" linkType="profile">
+                      <modifiers>
+                        <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                          <conditions>
+                            <condition parentId="2482-d9be-1958-b6e3" childId="9efd-e2df-ab50-2962" field="selections" type="at least" value="1.0"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups>
+                <entryGroup id="49e4-d7e0-4dfb-a615" name="Special Weapons" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="853c-fa60-9d70-1864" name="Boy w/ Big Shoota" points="10.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries>
+                        <entry id="1c7a-1cf2-fadf-98b1" name="Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="ed10-0d57-c1cd-5391" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="7d3b-4df8-208a-9299" name="Choppa" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="200c-ed75-52a6-30a1" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="338d-a6aa-adbd-e8a2" name="Stikkbombs" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="3530-52b0-e7c3-ee5d" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                      </entries>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="0d8b-b911-b9dc-684d" targetId="eb659805-d021-ab73-c776-3017ac5c3d26" linkType="profile">
+                          <modifiers>
+                            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                              <conditions>
+                                <condition parentId="2482-d9be-1958-b6e3" childId="9efd-e2df-ab50-2962" field="selections" type="at least" value="1.0"/>
+                              </conditions>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                        </link>
+                      </links>
+                    </entry>
+                    <entry id="dd5f-7ac4-a430-2431" name="Boy w/ Rokkit" points="10.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries>
+                        <entry id="363e-28f1-73d8-417b" name="Rokkit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="277a-50c9-a24f-b2c9" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="2998-d569-dc39-22f9" name="Choppa" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="ea09-c7e9-5d5d-6157" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                        <entry id="c82a-cd29-6662-e1e4" name="Stikkbombs" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+                          <entries/>
+                          <entryGroups/>
+                          <modifiers/>
+                          <rules/>
+                          <profiles/>
+                          <links>
+                            <link id="6018-3fa3-46b1-fbb0" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" linkType="profile">
+                              <modifiers/>
+                            </link>
+                          </links>
+                        </entry>
+                      </entries>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles/>
+                      <links>
+                        <link id="1275-22d1-a724-9406" targetId="eb659805-d021-ab73-c776-3017ac5c3d26" linkType="profile">
+                          <modifiers>
+                            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                              <conditions>
+                                <condition parentId="2482-d9be-1958-b6e3" childId="9efd-e2df-ab50-2962" field="selections" type="at least" value="1.0"/>
+                              </conditions>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers>
+                    <modifier type="increment" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="2482-d9be-1958-b6e3" incrementChildId="afb6-8f6b-a4b1-eb80" incrementField="selections" incrementValue="10.0">
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <links/>
+                </entryGroup>
+              </entryGroups>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="0cbc-94de-05eb-f6e5" name="Boss" defaultEntryId="cf00-b8a0-8546-b5f9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="cf00-b8a0-8546-b5f9" targetId="a051-8109-fd9d-b174" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="84cb-3750-a11f-636c" targetId="89d5-f953-1c6d-4322" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="284b-8d72-0cff-434e" name="Green Tide" hidden="false" book="Waaagh! Ghazghkull (Old Version via GW FAQ)" page="59">
+          <description>All of the units of Boyz and the Warboss form a single unit known as the Green Tide.  the Warboss cannot leave this unit.  The Green Tide Counts as 11 units for Victory Points purposes if it is completely destroyed.  If the Green Tide ever rolls a Breaking Heads or Squabble result on the Mob Rule table, any resulting hits are allocated by the Formation&apos;s controlling player</description>
+          <modifiers/>
+        </rule>
+        <rule id="de10-b682-75c8-0b8d" name="Waaagh! Horde" hidden="false" book="Waaagh! Ghazghkull (Old Version via GW FAQ)" page="59">
+          <description>Models in the Green Tide gain the Hammer of Wrath special rule in any Assault phase in which they successfully charge an enemy unit and the dice rolled for their charge range is 10 or more (before modifiers).  Note that the unit does not need to move the full distance rolled to gain the effect.</description>
+          <modifiers/>
+        </rule>
+        <rule id="04a9-91da-6adc-971e" name="Stampede" hidden="false" book="Waaagh! Ghazghkull (Old Version via GW FAQ)" page="59">
+          <description>If the Formation&apos;s Warboss is your Warlord, he can use the WAAAGH! special rule each and every turn after the first.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="ad81-cfe2-3e48-eb04" targetId="199a26c2-88ac-f821-c1c0-53f52e909d28" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="7661-2f51-6b4d-da71" targetId="afb0365f-84ca-20de-65e9-edc890f35661" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f619-7b9f-c432-4a7e" targetId="e26b2446-8e7f-8037-3b9c-4db2424312be" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="f29c-b880-0ae9-b1b8" name="Fighta-boma Flyer Wing (FW)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="FW Update for DFtS" page="1">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4d30-05b8-80db-889f" name="Fighta-Bomas" defaultEntryId="239e-40dd-12de-f0ad" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="239e-40dd-12de-f0ad" targetId="d8d0-0523-ea27-c3fc" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="d8d0-0523-ea27-c3fc" name="Fighta-bomba (FW)" points="170.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour - Aeronautica" page="41">
+      <entries>
+        <entry id="8ce8-0559-7034-63f1" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="03ad-f583-7ce9-988f" targetId="0659c2f0-2ade-4c75-631f-ff484780df39" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="7893-9baa-d56d-92e0" name="Turret-mounted Twin-linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="b02b-a667-effe-9473" targetId="6d5f6f18-bf6d-7687-3e84-c01fcaeb12d3" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="012d-5541-23b0-8ac3" name="Twin-linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="238c-ca28-c818-5042" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="b71a-c98e-00c6-4697" name="Must Choose 6" defaultEntryId="2135-b44b-f3b2-5a13" minSelections="6" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="a297-a0ba-99ff-b04f" name="Bomm" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="7547-e0be-f310-ccb6" targetId="ae0f5463-1c63-689b-7ebb-3a38556e75c4" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="03a9-826c-b35a-d2b3" name="Grot Bomm" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="2adc-2b02-c41e-17ac" targetId="d62f6cb7-1f98-2a5a-9e02-e3adf91ae3fa" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="50d4-9c5d-665f-d1cc" targetId="6df5fbe0-2c1e-43e1-72b3-21e0b001aae3" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="2135-b44b-f3b2-5a13" name="Rokkit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="aa56-b7b0-f7dc-be45" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="4b38-5daf-7856-fd6a" name="Or 1 (Apoc Only)" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="7d3d-26e8-e44c-dfc3" name="Apocalypse Bomms" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="0246-ec0e-d3d7-ec56" targetId="8dc12681-f827-3593-06a6-ea0607823a59" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="2cf5-3f12-4dfe-3fb5" name="Burna Bomms" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="1467-a999-3342-b0c9" targetId="fd0c63e9-e80a-65af-c813-7cd43f021bb6" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="force type" childId="3bfe125e-5674-06d5-082f-f7f577ea26fc" field="selections" type="instance of" value="0.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers>
+            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="d8d0-0523-ea27-c3fc" childId="4b38-5daf-7856-fd6a" field="selections" type="at least" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="d8d0-0523-ea27-c3fc" childId="4b38-5daf-7856-fd6a" field="selections" type="at least" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="820f-14a4-eb80-bdef" targetId="d6b536dd-36ae-1baf-53a7-df8fa5944191" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="2e5d-ae60-eb3d-aef2" targetId="90311584-d42b-5056-1554-0c859a6db9ab" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8b95-8e1c-bac8-7307" targetId="eb95dad9-5e29-2474-4d99-3874751f67c1" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7bc3-a212-22d2-4df9" targetId="381bb905-a0f2-f66b-13ee-74bbf271a5cf" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a389-2e04-532e-fd4c" name="Warkopta Skwadron (FW)" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dread Mob PDF &amp; Forgeworld DFtS update" page="12">
+      <entries>
+        <entry id="f542-6f1d-d52a-d107" name="Warkopta" points="65.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups>
+            <entryGroup id="ea6e-5c6a-a892-1a0a" name="May Take Any" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="5a80-b8d6-93cf-2ed6" name="Bigbomm" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="39d4-46c5-02de-afd4" targetId="c5e4c919-08f6-f38a-75a4-84ce0ddf51b5" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="c739-21cb-76b0-7325" name="Red Paint Job" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="3123-40bd-b837-d03e" targetId="7bf40f92-7deb-b55d-e8e0-578efa16dc3d" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="d66b-4bfa-1388-6aad" name="Stikkbomb Chukka" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="5904-c0f6-97ea-af5c" targetId="e78e5295-6e2c-9389-56d9-cfe46b133003" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+            <entryGroup id="a88a-7592-39f4-53d7" name="Must Take 1" defaultEntryId="523d-4cfb-aac8-d03c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="523d-4cfb-aac8-d03c" name="Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="9309-13c8-4391-8a9d" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="6221-636e-dcc5-09e0" name="Kustom Mega-blasta" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="667c-6469-35bb-571f" targetId="40a0dc73-b56e-6e3c-2239-e1bb69f1c2fb" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="3268-b519-70d7-cb2f" name="Rokkit Launcha" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="55e7-6f00-6b86-fa7e" targetId="076b7eee-123d-6d81-3099-053319f2ada6" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="adbb-afc2-8563-a095" name="Skorcha" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="90f0-8486-f7cb-35d0" targetId="112524d5-cde4-68b6-6545-12453b78417e" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+            <entryGroup id="5213-6ae7-505f-6f40" name="Must Take 1" defaultEntryId="0ed6-30e5-5155-9dcd" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="0ed6-30e5-5155-9dcd" name="Twin-linked Deffgun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="7914-07d9-1cd6-49ae" targetId="569bd8eb-a569-4aff-e138-874d90968771" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="1712-bca4-7f3a-4439" name="Twin-linked Rattler Kannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dread Mob PDF" page="12">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="c942-8cc1-3461-fb55" targetId="30130129-53bf-fc38-6ebe-cd4a4d6c31f9" linkType="profile">
+                      <modifiers/>
+                    </link>
+                    <link id="34d2-efa5-27f1-5d57" targetId="469df92c-cf8a-7217-5827-4b5308be4d1f" linkType="rule">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules>
+            <rule id="9143-4e1b-db98-7060" name="Forgeworld Doesn&apos;t Understand Fliers" hidden="false" book="Forgeworld Death from the Skies Update" page="1">
+              <description>These ground vehicles, Drop Pods or Skimmers may transition into Zooming Flyers in a temporary fashion. They gain the benefits of Agility, Pursuit and Combat
+Roles only while operating as Zooming Flyers. If they exit the board into Ongoing Reserves as Zooming Flyers, they may be targeted during the Dogfight phase, but do not count for determining Air Superiority</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links>
+            <link id="7832-4e88-0f59-8b3f" targetId="96f7edc0-4791-34b9-19fd-2632e268e867" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="99be-1be1-f4e1-4e5b" targetId="e5be-154b-56bf-f644" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="1698-7849-444e-a126" name="Attak Fightas (FW)" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour - Aeronautica" page="42">
+      <entries>
+        <entry id="4dfa-5d66-62e1-7911" name="Attak Fighta" points="95.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="a6be-caee-810c-a5e3" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="cda2-3a24-478f-f8fc" targetId="0659c2f0-2ade-4c75-631f-ff484780df39" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="8312-ff92-149f-35d5" name="Twin-Linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="82de-7298-3378-ce87" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="4cb9-3afe-4ca0-1686" name="Must Choose 1" defaultEntryId="1edc-4209-83c6-0f42" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="1edc-4209-83c6-0f42" name="2x Bomms" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="b9c7-caea-2517-bb98" targetId="ae0f5463-1c63-689b-7ebb-3a38556e75c4" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="7bae-dc25-00c8-c34c" name="2x Rokkits" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="8820-2942-c15a-3349" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="eb40-5aa3-3699-ada9" targetId="8b2014ba-8549-779b-fde6-57272a8177a9" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="bbe6-5ccb-bf8d-fd0b" targetId="90311584-d42b-5056-1554-0c859a6db9ab" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="f72e-00b4-da39-bece" targetId="381bb905-a0f2-f66b-13ee-74bbf271a5cf" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="5050-46db-f558-7503" targetId="eb95dad9-5e29-2474-4d99-3874751f67c1" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="02f5-4228-4450-3d67" name="Attak Fighta Flyer Wing (FW)" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="bf36-1148-a721-d413" name="Attak Fighta" points="95.0" categoryId="(No Category)" type="unit" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour - Aeronautica" page="42">
+          <entries>
+            <entry id="776d-c8fa-ba0f-2c5e" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="10f9-f9d1-e625-3449" targetId="0659c2f0-2ade-4c75-631f-ff484780df39" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3ddd-854d-9a73-da8c" name="Twin-Linked Big Shoota" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="4fdb-dbc0-91e7-f7cc" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="d723-b991-faee-24c2" name="Must Choose 1" defaultEntryId="604e-cab6-b15d-4ca0" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="604e-cab6-b15d-4ca0" name="2x Bomms" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="7776-8d53-995f-71bf" targetId="ae0f5463-1c63-689b-7ebb-3a38556e75c4" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="019a-966e-cc2d-3572" name="2x Rokkits" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="1cd0-17f6-5ae2-87f0" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="9aaf-b3aa-31c8-b9de" targetId="8b2014ba-8549-779b-fde6-57272a8177a9" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="11e4-65e1-3466-8b64" targetId="90311584-d42b-5056-1554-0c859a6db9ab" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="ab8a-ab22-298c-d410" targetId="eb95dad9-5e29-2474-4d99-3874751f67c1" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="a16a-1eba-fbea-d06b" targetId="381bb905-a0f2-f66b-13ee-74bbf271a5cf" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
   </sharedEntries>
   <sharedEntryGroups>
     <entryGroup id="aace-8396-c4bc-03e1" name="Big Mek Mega Ranged Weapon" defaultEntryId="54fa-daf6-f199-7610" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -26045,6 +26509,37 @@
           <profiles/>
           <links>
             <link id="4b7f-ebf1-bc77-7b63" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <links/>
+    </entryGroup>
+    <entryGroup id="fb41-3b79-e0eb-0343" name="Mek Melee Weapons (Upgrade)" defaultEntryId="90c7-337f-ceb3-d0b1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="90c7-337f-ceb3-d0b1" name="Choppa" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="39d3-7b28-be8f-79a7" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="3a52-614c-05f6-72f9" name="Killsaw" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="7dd9-5647-bb95-5b69" targetId="0e4f3e53-4dae-120f-149e-8cc799313b51" linkType="profile">
               <modifiers/>
             </link>
           </links>
@@ -27013,9 +27508,9 @@ Execute the Bombing Run attack normally. In addition, the flyer making the attac
         <characteristic characteristicId="a4cb-791a-6a75-4e4a" name="Rear" value="10"/>
         <characteristic characteristicId="93e6-d4b1-28a8-944b" name="HP" value="2"/>
         <characteristic characteristicId="eb65-838c-8eaa-8b5d" name="Type" value="Flyer"/>
-        <characteristic characteristicId="d477-c087-173f-9f1c" name="Combat Role" value="N/A"/>
-        <characteristic characteristicId="e04d-332e-8b52-0071" name="Pursuit" value="N/A"/>
-        <characteristic characteristicId="ae34-f5c0-19af-4883" name="Agility" value="N/A"/>
+        <characteristic characteristicId="d477-c087-173f-9f1c" name="Combat Role" value="Interceptor"/>
+        <characteristic characteristicId="e04d-332e-8b52-0071" name="Pursuit" value="4"/>
+        <characteristic characteristicId="ae34-f5c0-19af-4883" name="Agility" value="2"/>
       </characteristics>
       <modifiers/>
     </profile>
@@ -27775,9 +28270,9 @@ Execute the Bombing Run attack normally. In addition, the flyer making the attac
         <characteristic characteristicId="a4cb-791a-6a75-4e4a" name="Rear" value="10"/>
         <characteristic characteristicId="93e6-d4b1-28a8-944b" name="HP" value="3"/>
         <characteristic characteristicId="eb65-838c-8eaa-8b5d" name="Type" value="Flyer"/>
-        <characteristic characteristicId="d477-c087-173f-9f1c" name="Combat Role" value="N/A"/>
-        <characteristic characteristicId="e04d-332e-8b52-0071" name="Pursuit" value="N/A"/>
-        <characteristic characteristicId="ae34-f5c0-19af-4883" name="Agility" value="N/A"/>
+        <characteristic characteristicId="d477-c087-173f-9f1c" name="Combat Role" value="Strike-fighter"/>
+        <characteristic characteristicId="e04d-332e-8b52-0071" name="Pursuit" value="3"/>
+        <characteristic characteristicId="ae34-f5c0-19af-4883" name="Agility" value="2"/>
       </characteristics>
       <modifiers/>
     </profile>
@@ -29886,14 +30381,17 @@ Execute the Bombing Run attack normally. In addition, the flyer making the attac
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="96f7edc0-4791-34b9-19fd-2632e268e867" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Warkopta" hidden="false" book="Dred_Mob.pdf" page="0">
+    <profile id="96f7edc0-4791-34b9-19fd-2632e268e867" profileTypeId="3a08-ea03-a598-8615" name="Warkopta" hidden="false" book="Dred_Mob.pdf" page="0">
       <characteristics>
-        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="2"/>
-        <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="10"/>
-        <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="10"/>
-        <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
-        <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
-        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Fast, Open-topped, Skimmer, Transport"/>
+        <characteristic characteristicId="9878-e3f6-b7b4-7225" name="BS" value="2"/>
+        <characteristic characteristicId="3a4e-bc1d-4a12-7176" name="Front" value="10"/>
+        <characteristic characteristicId="d12e-7bdb-191c-4849" name="Side" value="10"/>
+        <characteristic characteristicId="a4cb-791a-6a75-4e4a" name="Rear" value="10"/>
+        <characteristic characteristicId="93e6-d4b1-28a8-944b" name="HP" value="2"/>
+        <characteristic characteristicId="eb65-838c-8eaa-8b5d" name="Type" value="Fast, Open-topped, Skimmer, Transport"/>
+        <characteristic characteristicId="d477-c087-173f-9f1c" name="Combat Role" value="Attack Flyer"/>
+        <characteristic characteristicId="e04d-332e-8b52-0071" name="Pursuit" value="1"/>
+        <characteristic characteristicId="ae34-f5c0-19af-4883" name="Agility" value="2"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
Closes #2284
Closes #2386
Closes #2374

The Warkopta was assumed to be a skimmer with DFtS rules even though it
was mispelled, and didn't have the asterick.
