### PR TITLE
remove maxSelection from Ravenwing Darkshroud

### DIFF
--- a/Dark Angels - Codex (2015).cat
+++ b/Dark Angels - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="578f-d512-a02e-7d0b" name="Dark Angels: Codex (2015)" book="Dark Angels Codex 2015, 7th Edition" revision="53" battleScribeVersion="2.00" authorName="Thairne" authorContact="Interrogatorchaplain@gmx.de" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="578f-d512-a02e-7d0b" name="Dark Angels: Codex (2015)" book="Dark Angels Codex 2015, 7th Edition" revision="54" battleScribeVersion="2.00" authorName="Thairne" authorContact="Interrogatorchaplain@gmx.de" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -25707,9 +25707,7 @@ The Knight has a 4+ invulnerable save against all hits on that facing until the 
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>


### PR DESCRIPTION
After going through the DA Codex I can't see a reason to why you should only be able to field one Darkshroud