### PR TITLE
Fix Constraints on Ork Formations

### DIFF
--- a/Orks - Codex.cat
+++ b/Orks - Codex.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5e29cf46-0edb-4f2a-8b49-7691fba3e163" name="Orks: Codex (2014)" revision="2003" battleScribeVersion="2.00" authorName="tag8833" authorContact="tag8833@yahoo.com" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="2000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5e29cf46-0edb-4f2a-8b49-7691fba3e163" name="Orks: Codex (2014)" revision="2004" battleScribeVersion="2.00" authorName="tag8833" authorContact="tag8833@yahoo.com" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="2000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks>
@@ -1603,657 +1603,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab3c-18f9-1f48-8d25" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcee-97cf-9099-b2cd" type="max"/>
           </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9f76-4af6-09f7-7948" name="&quot;Painmob&quot;" book="Start Collecting! Orks" hidden="false" collective="false" categoryEntryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e444-1b08-5c8d-d597" hidden="false" targetId="d12a-2728-5e61-78d4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4a7bc38-f85c-0552-d50c-cf3640222184" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="3969-5cac-a51b-8887" name="Deff Dread" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="dc99-e463-e857-d958" hidden="false" targetId="e108654d-936f-47e0-f1b8-85a2957bef11" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4d3d-0fe8-b10d-2f1a" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7d78-42a5-5dff-f465" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="98d4-d98e-8000-eb43" name="May Choose Any" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="07b2-b7de-210e-9afd" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="3fe9-094a-cb27-f8c0" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="64ed-0cc6-dabc-f471" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="5030-a18e-1024-7e70" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="b745-e6c5-05f2-f269" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="99b2-0e7b-d8f4-1302" hidden="false" targetId="056f-0d8c-4617-6065" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="80.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="90f5-8c83-e590-8d01" name="Nobz" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1607-fa4d-4419-c7fc" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0f41-8136-1caa-eb2c" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="adeb-1f65-b7be-cec3" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a4a6-6ba8-4148-8029" name="Waaagh! Banner" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9669-afe5-55d9-a0e0" hidden="false" targetId="9b7aeca8-8dd0-30cb-9db2-f0e2be23dfa4" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4d5e-c64d-5d14-19eb" name="Boss Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3533-3039-a7d3-6802" hidden="false" targetId="47abc561-469a-0e41-00e8-5d9ea56484bc" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1bff-7de4-2878-47f3" type="equalTo"/>
-                            <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bike (Character)">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="58b6-d7c2-24ac-e9d3" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="bef9-9969-6aa2-3a8e" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="9679-eb27-b208-efe6" name="May Choose Any" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="7168-a01d-edb8-5959" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="34b0-f259-3089-ac34" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="3.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="cfd8-6a0b-39de-8f69" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f7f9-5a7c-0dbf-9bd5" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="0ac4-d4ac-4bca-cfac" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="e2c4-57e3-7bc5-5429" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="610f-d9cb-68b4-0528" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5a2d-8ce8-e909-8f7e" name="Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="22d5-0605-bc49-d48f" hidden="false" targetId="27e260dc-e603-a3d7-d0ed-ee4b8ae523f1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1bff-7de4-2878-47f3" type="equalTo"/>
-                            <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bikes">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="7c96-65f1-02f5-342f" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b130-21cc-af64-42a5" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="d584-466c-2db9-a081" name="May Choose Any" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="0b00-6f81-853a-35b8" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="d507-e5c6-52e6-2747" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="3.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="6019-435d-e10f-7382" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="e056-d947-9400-33a3" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="6c10-93d4-d65d-7f66" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="1c38-2a25-981f-8744" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="710b-8a3a-0a48-8754" name="Dedicated Transport" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="09ec-55c1-1105-8f1d" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="11b2-9e3d-6510-5095" hidden="false" targetId="8ea5c639-80eb-bf9f-0194-8033746e1f42" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="e4e3-c534-c80d-6491" hidden="false" targetId="e52a209b-b0ff-5b42-5478-981eb7ab6808" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="61c8-70ea-ec64-6f00" name="Entire Mob May Take" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="09ec-55c1-1105-8f1d" name="Warbikes for Mob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="fcda-a9ee-1849-05af" hidden="false" targetId="7d37a85a-e247-b485-63de-99099729b08f" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="27.0">
-                      <repeats>
-                        <repeat field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5a2d-8ce8-e909-8f7e" repeats="1"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="cae8-935b-0289-bff1" name="Twin-linked Dakkaguns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="8366-609c-de1d-e77c" hidden="false" targetId="eaa8e75b-082b-e14a-5e96-b7e729646618" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="27.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1bff-7de4-2878-47f3" name="&apos;Eavy Armour for Mob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6a8f-271e-b831-f26b" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="4.0">
-                      <repeats>
-                        <repeat field="selections" scope="90f5-8c83-e590-8d01" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5a2d-8ce8-e909-8f7e" repeats="1"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="4.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="5e86-253e-d21a-e7ab" hidden="false" targetId="ba28-9d0a-4872-eaf9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="470e-b98f-6139-b284" hidden="false" targetId="c55d-5a8f-437a-373a" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
         </entryLink>
       </entryLinks>
       <costs>
@@ -7779,242 +7128,6 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b7a79c54-b215-1e5f-3c58-4f498c029d7b" name="Boss Zagstruk, Da Boss" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a02f15d0-3e43-3e76-ee6c-17df54339ac7" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="cabc93fa-fb94-46aa-c7f6-a691b6683227" hidden="false" targetId="beccfd4d-727c-b85e-2bc7-82d4855fc906" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="bac8e521-2d24-7cd5-66a5-a4fe410baac0" hidden="false" targetId="58758be2-d4f4-2ae1-5b2d-e9c4128aec04" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b37f2761-5e53-981a-eb7d-1e9c9e3fecd1" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="db2e67ae-c15e-b34f-6c18-962a257455ef" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="09d2132e-d325-b542-11e2-d37854c82f21" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="8a6cad03-2b50-6893-a2c2-3efc5a180df4" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="521f634c-39ee-f698-c739-da066aadd2a7" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="ad6083eb-6533-3dfb-657b-de6b2d3dc95b" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a9de6e75-c9a0-d107-e068-5d9e3d400811" name="Da Vulcha&apos;s Klaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="8b7f7197-e8bb-7c9d-0469-9dffa12a1c21" hidden="false" targetId="9636d31c-6837-f767-9187-aefcc0470727" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="708ec44c-25de-5b10-46dd-41555680de51" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="52dfa417-6ffd-5bfb-0280-3045aada5bf0" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e5fe1842-9873-c120-30d9-cacfe1f254ef" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d257da10-d6c9-103e-209f-ddc6a8abceff" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="cd60e1ff-f983-f9ed-a927-dd4dd51b3da6" name="Rokkit Pack" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="0ec319fd-c3e6-b579-5ace-e44cf397bf5b" hidden="false" targetId="00b19c1b-2e18-0f04-52df-aeb27c8d139a" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a288b4a1-f8c6-51b9-2c61-f8ed20bcefa1" name="Choppa" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1840a96c-924f-7aea-2585-1619b079ce1f" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0f2ed5fa-a6ce-358b-8628-79eb22193abc" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1f724442-7a7b-0e35-eae4-b930e14c86b9" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="cb87e6e3-84be-1080-89f3-a9771fc7ea39" hidden="false" targetId="a9d2-7495-983f-54a6" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="d1dbad5e-5e09-038e-5719-0d5cb2e1d817" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="65.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6537530a-0c08-9246-47ed-b0fa309a8499" name="Dethrolla Battle Fortress (FW)" book="Imperial Armour VIII - Raid on Kastorel-Novem" page="169" hidden="false" collective="false" categoryEntryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="model">
       <profiles/>
       <rules/>
@@ -11689,154 +10802,6 @@
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
       <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f43322ad-a15d-a505-5521-f6a4fc7f6919" name="Killa Kans" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a20929fd-300f-0d32-afe8-f942cd407f75" hidden="false" targetId="5cd704ba-04d7-96c1-17fe-be4fb093117c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4a7bc38-f85c-0552-d50c-cf3640222184" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="d898a1da-1029-d4b1-4616-7b1f0b699cac" name="Killa Kan" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="37e86836-db64-05cc-4682-a79fd88c4f21" hidden="false" targetId="c798f715-ec69-02f8-aaf3-ff7bc3171cf2" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="eec7bf5a-867e-7b39-c733-e4803b895a11" name="Kan Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d73cb044-8014-7dae-23ee-38fab7f1d141" hidden="false" targetId="07f43816-45a2-2e82-d805-1c603ef2c5b5" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="251c31ca-d6a1-a3af-c927-a3fcd5d65192" name="May Choose Any" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="b90c50a2-b04f-2b7c-613c-00dc984b94fe" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="910b2d72-333b-2af5-0521-028298f77874" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="8d4f3e37-7de8-3db0-0280-780fd5d2a118" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="aa198cb2-64bf-fff8-b6d1-2e8ce3e08e97" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="2e9571d0-7488-d6df-ff70-ef8f06e79a69" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="a89a-1055-3a0c-701a" hidden="false" targetId="03be-c490-b054-b185" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="50.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
@@ -16637,13 +15602,6 @@
       <modifiers/>
       <constraints/>
     </entryLink>
-    <entryLink id="f780-908a-dc53-260d" hidden="false" targetId="76d885d1-61ae-138e-9d56-151523fd1e55" type="selectionEntry" categoryEntryId="9050-d437-3301-7e42">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </entryLink>
     <entryLink id="09d7-70c8-4956-e01f" hidden="false" targetId="f409-6809-fe8c-c3a4" type="selectionEntry" categoryEntryId="ef2b-83bd-1bad-5742">
       <profiles/>
       <rules/>
@@ -16764,13 +15722,6 @@
       <constraints/>
     </entryLink>
     <entryLink id="02eb36f8-bb0c-4ad7-9566-68eb7858d65d" hidden="false" targetId="c55d-5a8f-437a-373a" type="selectionEntry" categoryEntryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </entryLink>
-    <entryLink id="5cfa-1bc9-56d0-340e" hidden="false" targetId="372b-1513-7e47-91de" type="selectionEntry" categoryEntryId="9050-d437-3301-7e42">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -16955,6 +15906,27 @@
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2615-8e7a-a3ab-0f49" type="max"/>
       </constraints>
     </entryLink>
+    <entryLink id="3527-f286-0e7a-420b" name="New EntryLink" hidden="false" targetId="617b-779d-5627-57b7" type="selectionEntry" categoryEntryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="2aa6-5072-bcb5-fb2f" name="New EntryLink" hidden="false" targetId="28a6-3572-7007-29e6" type="selectionEntry" categoryEntryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="728d-a919-e56c-e42e" name="New EntryLink" hidden="false" targetId="0a4f-93b3-5796-1eec" type="selectionEntry" categoryEntryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="e11b-1d87-be1b-159e" name="&quot;Air Armada&quot;" book="Waaagh! Ghazghkull (2016)" page="69" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
@@ -17117,7 +16089,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c89b-1b7a-3c2b-d3e9" hidden="false" targetId="dc65-bda8-8288-be9a" type="rule">
+        <infoLink id="c736-0ac2-138b-c1ab" name="New InfoLink" hidden="false" targetId="1794-e0e0-bedf-e46b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -17126,484 +16098,30 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="b28d-d414-ce79-194c" name="Battlewagon" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="30b4-9ab9-9258-4e9c" name="Battlewagons" hidden="false" collective="false" defaultSelectionEntryId="d8a6-00b6-795e-1604">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="aeea-6817-47e2-92fa" hidden="false" targetId="60331614-dbb2-bb17-81ac-f3f1e242da00" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Tank, Transport">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="b28d-d414-ce79-194c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f74d-5f05-805f-aad8" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="a91b-7c11-c303-1047" hidden="false" targetId="b1b4-1055-57bc-afd9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="15aa-1916-a38b-d223" value="12">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="b28d-d414-ce79-194c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0af9-9651-27c3-6117" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="fe20-e124-2c11-86ee" value="5: Two on either side, and One at the rear">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="b28d-d414-ce79-194c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f74d-5f05-805f-aad8" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="21e5-4518-a31c-7e56" value="3: One on either side and One at the rear">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="b28d-d414-ce79-194c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f74d-5f05-805f-aad8" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ff9-00bc-9c58-9d26" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="260e-3723-61c7-3c69" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="c11e-bdaa-9c91-f956" name="Must Choose 1" hidden="false" collective="false" defaultSelectionEntryId="7abc-0658-98dc-dfad">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="7abc-0658-98dc-dfad" name="Reinforced Ram" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="36f9-b723-fdce-fade" hidden="false" targetId="64b6528a-1ead-9394-7efb-b9a96697e620" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5600-85e8-2806-2d6e" name="Deff Rolla" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c940-1e53-3680-bd4e" hidden="false" targetId="68836e7e-b7c5-850e-31ec-6c552653878b" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="81cd-c4f2-963e-dc9e" name="May Choose 1" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="c376-8e12-61c5-0c99" name="Kannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="513d-f15d-4e2d-9512" hidden="false" targetId="a42ba073-2fa2-9184-8c16-992a5d234833" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="9c8f-7f12-b18f-220c" hidden="false" targetId="768cc4da-e03b-8216-e624-f4e37ff5123d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="00b9-7ba4-e797-9766" name="Lobba" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="8f5d-f5a0-032b-2d3f" hidden="false" targetId="5c81cd11-fe96-9b00-b7d7-a6dbb5c4abaf" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="be34-c75b-c578-5ff7" name="Zzap gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="196e-d507-4dea-71bb" hidden="false" targetId="da17cbb0-c90a-2a17-18bd-5af8925eefb3" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="f5c1-a032-d9a5-82c7" name="May Choose 4" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="792f-1605-4e1b-4df2" name="Big Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="7663-dd6e-b01d-a248" hidden="false" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="cc5e-a10d-30ba-d523" name="Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="cf55-1538-2a99-cc80" hidden="false" targetId="076b7eee-123d-6d81-3099-053319f2ada6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="c022-381a-6e6f-633b" name="May Choose Any" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d8a6-00b6-795e-1604" name="New EntryLink" hidden="false" targetId="8ea5c639-80eb-bf9f-0194-8033746e1f42" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="5a39-6038-2316-db15" name="Red Paint Job" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="dc58-af6a-76c7-b6df" hidden="false" targetId="7bf40f92-7deb-b55d-e8e0-578efa16dc3d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="c2dc-f557-8262-ac14" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="53ef-af64-46bf-ab26" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="8187-d4a2-35e2-2aa2" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="ec5a-5d6e-880e-9fa8" name="Boarding Plank" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="a906-cfa3-d620-27dc" hidden="false" targetId="a798f332-72a3-9e5e-0d32-d74a3fef3ee9" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="fe6e-948e-60c3-faf9" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="9de9-fcb9-bde1-f588" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="cb46-ca08-ad2d-f8b0" name="Stikkbomb Chukka" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c897-0a36-c7b7-8d76" hidden="false" targetId="e78e5295-6e2c-9389-56d9-cfe46b133003" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5fed-555b-f815-217d" name="Wreckin&apos; Ball" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="183f-f547-e663-d1a5" hidden="false" targetId="15bdb37c-7a7c-08f4-02cc-2825e14e715c" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="0af9-9651-27c3-6117" name="Killkannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="38c4-6003-5283-1a83" hidden="false" targetId="9325667c-b150-9893-a227-4971b51201b0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="30.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f74d-5f05-805f-aad8" name="&apos;Ard Case" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b224-2115-1648-d9eb" hidden="false" targetId="30f7730d-dcc5-54ee-0682-5936353e617a" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d7af-1b08-4ea2-836f" name="Grabbin&apos; Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c406-aed7-563b-92b6" hidden="false" targetId="cfe33a93-d3dc-5ca3-8a33-a0f390ad6739" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="110.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="a73c-1eba-176e-b3a7" hidden="false" targetId="199a26c2-88ac-f821-c1c0-53f52e909d28" type="selectionEntry">
           <profiles/>
@@ -17700,571 +16218,30 @@
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="3846-406f-f0b0-fb0a" name="Kommandos" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="172e-7de3-d730-45a8" name="Kommandos" hidden="false" collective="false" defaultSelectionEntryId="b819-58da-5679-0e9d">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="6913-ade5-140d-b16c" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="bdfb-53ea-2da2-e6a4" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0a82-230c-57a9-6c70" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b0b7-f959-5ec1-d383" hidden="false" targetId="7ecc-bc3d-6e22-63dc" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1f23-11a9-ae27-dbdc" hidden="false" targetId="0b11-a0ff-f0ba-5341" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="ade7-2dae-dd24-7798" hidden="false" targetId="2ee4-4ad5-04de-d3e2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde4-ebb5-847a-7740" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0543-0160-199f-1c6d" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="333a-cea5-cdc5-47c3" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="c81e-d7ee-9142-b5b9">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b819-58da-5679-0e9d" name="New EntryLink" hidden="false" targetId="fb7a-404f-c2bf-0c15" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="c81e-d7ee-9142-b5b9" name="Kommando" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="e5b1-005c-f489-6408" hidden="false" targetId="f560ae19-3ea6-eaab-4b9c-3f8945625eae" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="207d-8621-a925-1746" name="Choppa" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="62c1-6048-4bef-b7e2" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="b208-29c8-3dd5-ea40" name="Slugga" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="47a7-1855-7fcf-482c" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="96ff-35c6-4c74-cdc0" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="2a10-e08b-762b-8843" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8faf-107f-f570-f1e4" name="Boss Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="0e01-be53-3cea-a9b0" hidden="false" targetId="47abc561-469a-0e41-00e8-5d9ea56484bc" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="f3f5-ecbe-c04c-0cb2" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="8ff7-e4d1-f099-b7e8" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="b1d6-fb84-2f13-924c" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f272-15ba-70fa-d07e" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="9c3b-e182-985e-fc39" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="2b17-4193-f28a-1b1e" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="5388-6e3b-e6ac-775f" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="af09-25fb-18f5-ee94" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="216b-20e9-a507-4002" name="May Choose 2" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="edd5-d153-aa4e-50c6" name="Kommando w/ Burna" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="56ce-9e13-250a-3bf9" hidden="false" targetId="f560ae19-3ea6-eaab-4b9c-3f8945625eae" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="6059-6807-4912-6eb1" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="1587-db82-8aac-7e81" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="bd7c-e020-bcaa-a3bf" name="Burna" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="0bed-3cbf-99b6-78f5" hidden="false" targetId="447884ca-0a91-2d50-6183-2f7d81116dd5" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="7556-1aeb-e8b5-0866" hidden="false" targetId="6c8758e8-24c9-e5ed-761f-d7886f9cac68" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="92b5-cdea-b375-04de" name="Choppa" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="842a-d7f5-af67-81ef" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="25.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5bda-ae1b-b7cd-dfba" name="Kommando w/ Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="1c42-2f82-3aff-eadc" hidden="false" targetId="f560ae19-3ea6-eaab-4b9c-3f8945625eae" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="5a7c-954f-76e9-bfd6" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="6b36-9d13-c9d9-eab5" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="373e-dcf5-2f59-94b0" name="Rokkit Launcha" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="e897-a974-9e02-97ba" hidden="false" targetId="076b7eee-123d-6d81-3099-053319f2ada6" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="b47e-ac39-406b-4364" name="Choppa" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="f9d3-c8e3-85db-9392" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="15.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="c3e1-af4f-dd4b-bc8d" name="Kommando w/ Big Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="d942-6e9e-d478-d172" hidden="false" targetId="f560ae19-3ea6-eaab-4b9c-3f8945625eae" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="eb44-fffa-4e83-da8a" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="24bb-8165-c63e-e2fc" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="f62f-0823-937f-28d1" name="Big Shoota" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="da4f-0baf-4af6-56f4" hidden="false" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="e1f0-c182-1d27-7979" name="Choppa" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="a193-e0f5-a560-5f16" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="15.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="0f94-b952-ab93-7682" hidden="false" targetId="13dee8fe-6a10-77a3-744d-dc8407bb6590" type="selectionEntry">
           <profiles/>
@@ -18380,1367 +16357,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="maxInRoster" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="999dcd87-d486-7693-2fe4-48c241ec54e5" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="2594-d69f-c1ed-672f" name="Nobz" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="26bf-0493-4f5f-ea5c" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="6458-1679-b46b-d933" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="12d4-62f7-7352-faa9" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="2d14-0e79-9afc-3813" name="Waaagh! Banner" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d972-bd73-0b1f-fd7a" hidden="false" targetId="9b7aeca8-8dd0-30cb-9db2-f0e2be23dfa4" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5840-a8c9-8b09-0818" name="Boss Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b864-e645-b1f6-b0fa" hidden="false" targetId="47abc561-469a-0e41-00e8-5d9ea56484bc" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="equalTo"/>
-                            <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9785-071e-c04d-7d18" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bike (Character)">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="1388-9267-513d-66ea" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="320c-aee7-c89b-9e44" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="1505-5167-09e7-9de7" name="May Choose Any" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="cab7-c428-3175-e720" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="0a22-56ee-a28f-f349" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="3.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="16d1-2cc0-297e-f984" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5313-4053-dc8c-8a27" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="35ae-c0b4-57a7-f381" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="5294-548b-06c4-f2d8" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="954c-4209-4a29-8bb7" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a789-d677-50cb-7dbc" name="Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d632-d329-322e-9c50" hidden="false" targetId="27e260dc-e603-a3d7-d0ed-ee4b8ae523f1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="equalTo"/>
-                            <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9785-071e-c04d-7d18" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bikes">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="793b-42e0-4edd-db9c" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="04ca-f83c-cb79-0d02" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="a0bd-4e1e-e60d-6411" name="May Choose Any" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="9e94-ce2d-ad24-138a" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f049-29ce-75cb-a486" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="3.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="d99e-8ed1-68b4-a2cd" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="e5f2-b9a5-0d0f-65e7" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="adc9-3786-0b7d-9bb1" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="15a8-6ccd-7915-1b07" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="e48b-e28f-3fdd-e6eb" name="Dedicated Transport" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8d-75b3-8257-0e72" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="d44b-ee32-7132-540b" hidden="false" targetId="8ea5c639-80eb-bf9f-0194-8033746e1f42" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="7b81-8b83-df51-7bb1" hidden="false" targetId="e52a209b-b0ff-5b42-5478-981eb7ab6808" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="9ffc-2dd3-4a27-3ccb" name="Entire Mob May Take" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="ee8d-75b3-8257-0e72" name="Warbikes for Mob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="a531-4b39-c062-2208" hidden="false" targetId="7d37a85a-e247-b485-63de-99099729b08f" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="27.0">
-                      <repeats>
-                        <repeat field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a789-d677-50cb-7dbc" repeats="1"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="d287-c189-a433-3dbf" name="Twin-linked Dakkaguns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="17e1-6b60-c564-99de" hidden="false" targetId="eaa8e75b-082b-e14a-5e96-b7e729646618" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="27.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="9785-071e-c04d-7d18" name="&apos;Eavy Armour for Mob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="81b3-6e8b-8f4a-e5c0" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="4.0">
-                      <repeats>
-                        <repeat field="selections" scope="2594-d69f-c1ed-672f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a789-d677-50cb-7dbc" repeats="1"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="4.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="105d-93f9-fc08-66f7" name="Ghazghkull&apos;s Leftenuntz" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="2293-b352-5b7f-8ade" hidden="false" targetId="fd7f4504-57fc-802c-dddb-e0c92d0ee751" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="b495-39a1-efdb-4e15" name="Council" hidden="false" collective="false">
+        <infoLink id="9d5b-1f56-5e50-13d8" name="New InfoLink" hidden="false" targetId="fd7f4504-57fc-802c-dddb-e0c92d0ee751" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="cb9b-3ede-231e-3d3b" name="Warboss w/ Mega Armour" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="46a7-2442-e797-378e" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="0564-d703-a2e7-003f" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="12d5-84da-7a9d-2da6" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ba18-11c8-6120-fdbb" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="423e-dc79-e704-288c" hidden="false" targetId="375f7f5f-99b7-cc4c-242d-7382b544b68f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="cb9b-3ede-231e-3d3b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c0f9-4ad2-90ab-a622" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="increment" field="5ee4ff0b-b244-4670-9d05-91d10f80c32e" value="1">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="9c0d-3767-24c8-f20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="105d-93f9-fc08-66f7" type="atLeast"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="c2c8-e8fb-c6c5-7f3e" hidden="false" targetId="3c4b757d-bd20-642e-9324-7e9012713139" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="0d23-5a73-c2c2-0860" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="cb80-914c-ae60-59fc" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="c0f9-4ad2-90ab-a622" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="3b85-7f00-3ea0-59dd" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="8fff-fd92-d3ce-7beb" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="5f90-a922-ef06-8af3" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="40.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="3497-2fce-e075-0d5a" name="May Choose Any Runts, Squigs &amp; Know-wots" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="3e11-e988-eaf0-61fb" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="29c6-9e33-b80a-8c6f" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="c274-09e1-f7de-2494" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="804b-b79a-ac39-44cf" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="635c-e204-89bf-6688" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="7956-5070-025d-fd75" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5e92-ed73-31ea-523f" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="15.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="e612-1d83-e983-7099" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="28cd-9f52-3f41-dda9" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="3.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5b37-282b-3fbb-76aa" name="Gitfinda" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="83db-9b6c-f43c-1e48" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="204b-00f8-d585-66bb" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="c9cd-81fe-cdea-e82a" hidden="false" targetId="599efb0d-5ca0-a20b-e052-05073a2a2c6c" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="625b-3144-1891-7bb3" hidden="false" targetId="c574a454-71f8-c18f-d43f-6af72311ee11" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="601c-2b63-f51e-c4f2" hidden="false" targetId="de54d4cd-6483-9424-6f35-200c3e61a859" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="9a3b-4f60-5119-c320" hidden="false" targetId="216c3599-d3f7-eae7-674a-c9535b05a44c" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="f202-07da-194d-1945" hidden="false" targetId="e5f3e3d6-49b9-6d71-1a03-8cd2af8554f8" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="4795-011e-231d-a93b" name="Gifts of Gork and Mork" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="fd2b-0d12-a9c3-b618" hidden="false" targetId="e8082e4a-deaa-4284-de95-d0b0bb9be10b" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="da57-0093-752d-ee5b" hidden="false" targetId="30cc6165-7121-a4c0-1262-e729b435b68f" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="8173-77db-22d2-f147" hidden="false" targetId="e1874b1b-7ca5-7fe1-5329-a0e073b0c230" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="maxSelections" value="0.0">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="cb9b-3ede-231e-3d3b" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="323a-d7ca-f0c8-0a6e" hidden="false" targetId="c0773bfa-69cd-5e61-7d16-35180db73f6e" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="0766-30d1-9573-2998" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="97ff-70b9-8563-df45" hidden="false" targetId="35f3-8e98-ddff-ca9e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="968a-d495-552b-f9db" hidden="false" targetId="23a5-d259-ea77-c8b6" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="60.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="78de-d4a1-8937-4e42" name="Warboss" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="875f-f56d-307a-35aa" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="150e-70c6-5e64-3e13" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="0ade-eef7-5ce5-bcc8" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="2f20-8305-1213-3149" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="deeb-f106-8218-b824" hidden="false" targetId="375f7f5f-99b7-cc4c-242d-7382b544b68f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b217-2ea7-3170-17a8" type="equalTo"/>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dbcd-07a3-ac19-bd6e" type="equalTo"/>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bike (Character)">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dbcd-07a3-ac19-bd6e" type="equalTo"/>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dbcd-07a3-ac19-bd6e" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                    <modifier type="increment" field="5ee4ff0b-b244-4670-9d05-91d10f80c32e" value="1">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="9c0d-3767-24c8-f20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="105d-93f9-fc08-66f7" type="atLeast"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="9981-069c-1579-5c78" hidden="false" targetId="3c4b757d-bd20-642e-9324-7e9012713139" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="5ece-ac77-193b-b327" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="2bb9-eedd-e4b0-8156" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b217-2ea7-3170-17a8" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="5203-66c7-9505-93af" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="4.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="8f44-0cc6-9e35-d134" name="May Choose Any Runts, Squigs &amp; Know-wots" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="11a5-4a0c-a5a5-d431" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="b022-0ca0-72b3-cad0" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="88ee-f6f1-8b6d-889b" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="b5fb-e2b8-65e6-3e2c" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="2353-d460-7c7d-db54" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="2af7-3e3b-d80c-e92a" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="6514-1bc3-b8c0-4001" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="15.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="1b5f-40fd-02d6-1f38" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="cfd7-b000-3dc9-4438" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="3.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="9a12-8969-b4fb-6762" name="Gitfinda" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="d6be-5c17-6ebc-52e9" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="dbcd-07a3-ac19-bd6e" name="Warbike" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="db7d-bb00-0edc-25fe" hidden="false" targetId="7d37a85a-e247-b485-63de-99099729b08f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="74a5-db28-cf45-6a63" name="Twin-linked Dakkaguns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="b4fc-1221-59f1-5969" hidden="false" targetId="eaa8e75b-082b-e14a-5e96-b7e729646618" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="25.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="2e41-918a-a475-1668" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="dfec-815b-47e0-c5cf" hidden="false" targetId="599efb0d-5ca0-a20b-e052-05073a2a2c6c" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="93f5-a6ae-fa42-2e78" hidden="false" targetId="c574a454-71f8-c18f-d43f-6af72311ee11" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="38b2-7b79-8446-1002" hidden="false" targetId="de54d4cd-6483-9424-6f35-200c3e61a859" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="dd38-e0c5-e75f-06f1" hidden="false" targetId="216c3599-d3f7-eae7-674a-c9535b05a44c" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="657a-46cd-4fdb-00a5" hidden="false" targetId="e5f3e3d6-49b9-6d71-1a03-8cd2af8554f8" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="43ee-c680-5c81-2288" name="Gifts of Gork and Mork" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="90cd-f319-32b5-2c18" hidden="false" targetId="e8082e4a-deaa-4284-de95-d0b0bb9be10b" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="9f8a-6bb1-8f3e-b21e" hidden="false" targetId="30cc6165-7121-a4c0-1262-e729b435b68f" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="c3ed-7a5f-0f7b-aa20" hidden="false" targetId="e1874b1b-7ca5-7fe1-5329-a0e073b0c230" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="maxSelections" value="0.0">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="a5f7-fa7a-8896-cf9c" hidden="false" targetId="c0773bfa-69cd-5e61-7d16-35180db73f6e" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="af92-b9e1-c94a-148e" hidden="false" targetId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="maxSelections" value="0.0">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="78de-d4a1-8937-4e42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dbcd-07a3-ac19-bd6e" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="3a19-708e-fd1e-72c5" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="b19e-9fac-4f6e-f5c4" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="198b-e809-83a8-35da" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="60.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
         <selectionEntryGroup id="38fc-4be2-be76-d7ba" name="Oddboy" hidden="false" collective="false" defaultSelectionEntryId="7a43-999a-4e8f-97e6">
           <profiles/>
           <rules/>
@@ -19753,14 +16382,70 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7a43-999a-4e8f-97e6" hidden="false" targetId="76d885d1-61ae-138e-9d56-151523fd1e55" type="selectionEntry">
+            <entryLink id="7a43-999a-4e8f-97e6" hidden="false" targetId="9e55-1c56-22d9-3e01" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="515d-2514-b594-4d4b" hidden="false" targetId="372b-1513-7e47-91de" type="selectionEntry">
+            <entryLink id="515d-2514-b594-4d4b" hidden="false" targetId="dc4f-2ba9-0af5-304d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6488-bebf-523c-015f" name="Leftenunt 1" hidden="false" collective="false" defaultSelectionEntryId="e833-4798-487a-565b">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4cb-1f2b-ca4c-c364" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e62-1c59-8d61-841e" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e833-4798-487a-565b" name="New EntryLink" hidden="false" targetId="24ba-2ca9-5ae8-b5ff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1ac9-9964-5df1-cf79" name="New EntryLink" hidden="false" targetId="6cfa-d1ae-de1d-24d0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="dee1-9cd9-7216-f5b9" name="Leftenunt 2" hidden="false" collective="false" defaultSelectionEntryId="94ae-79e3-9924-0c3c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bfc-1420-a47f-27e8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31c1-fa10-24f9-c9fb" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="94ae-79e3-9924-0c3c" name="New EntryLink" hidden="false" targetId="24ba-2ca9-5ae8-b5ff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="882b-4c5f-71b7-561e" name="New EntryLink" hidden="false" targetId="6cfa-d1ae-de1d-24d0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -19783,14 +16468,30 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffe2-bbd5-41a6-dc3a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d3c-4b2a-302f-7eb9" type="max"/>
+          </constraints>
         </entryLink>
         <entryLink id="9af2-8b67-51e1-61ef" name="" hidden="false" targetId="999dcd87-d486-7693-2fe4-48c241ec54e5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bda-f09b-8b04-da98" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ddd-1f9b-d386-8449" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f5ac-6d38-2a5c-9d11" name="New EntryLink" hidden="false" targetId="632cf00b-e88d-4c00-d57e-8965f2ad805b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f89-e7bf-9dd6-be59" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c949-2c5c-06b5-e7fa" type="max"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>
@@ -19832,532 +16533,25 @@
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers>
-        <modifier type="set" field="maxInRoster" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7a79c54-b215-1e5f-3c58-4f498c029d7b" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="62d7-1351-eb5d-52a0" name="Stormboyz" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0afd-66e2-2209-45e9" name="Stormboyz" hidden="false" collective="false" defaultSelectionEntryId="38bf-7c33-3030-f191">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="ea62-7ffd-fecb-40ef" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="f036-8d7b-e86b-0e4b" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="3f66-2ea3-bd58-09c6" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2bc-ce77-298b-d37b" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18eb-243a-04b1-6eaa" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="8af3-065a-c24b-b3de" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="428e-185c-709a-635f">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="428e-185c-709a-635f" name="Stormboy" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="7e87-a009-30fd-0368" hidden="false" targetId="39afe82f-f090-b37e-399d-d30258ebefdf" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="5cb7-f08a-df40-c04e" name="Rokkit Pack" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="3cdf-ee7e-ca19-21cc" hidden="false" targetId="00b19c1b-2e18-0f04-52df-aeb27c8d139a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5a99-2537-ac7a-3660" name="Choppa" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="9bb8-144a-a58a-e0d3" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="4266-6f85-1809-674d" name="Slugga" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="21cb-36c4-ef3b-ff3d" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="19ad-345b-a956-c873" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="c867-f453-b0ee-39e5" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="9.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d92d-4c95-9453-f721" name="Stormboy Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1d35-2400-da21-d126" hidden="false" targetId="6720463c-aa03-1f63-b35f-093fb1813ad6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="d387-1583-d7f0-bc25" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="7545-6450-f1ec-bf96" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="9f82-8ef5-e2d2-0b44" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="7bd5-3fd2-cf8f-a5f9" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="1e22-0ec7-5cce-cb51" name="Rokkit Pack" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="69da-3986-b3dd-5470" hidden="false" targetId="00b19c1b-2e18-0f04-52df-aeb27c8d139a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ea70-574d-437f-e199" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="3da8-4589-be5b-d38d" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="80bd-220d-f3bf-a33f" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="561e-74d7-cddd-2c03" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="19.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="cfb6-59f1-ad85-c1d0" name="Boss Zagstruk" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="e2ed-da47-9037-4fe5" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="70fa-6ad7-0a1a-8e38" hidden="false" targetId="beccfd4d-727c-b85e-2bc7-82d4855fc906" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a03a-b4b3-ee5a-07f8" hidden="false" targetId="58758be2-d4f4-2ae1-5b2d-e9c4128aec04" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="bde6-5057-543c-7622" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1f65-c1b4-f0c3-87d2" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c047-d0c2-b40d-ce52" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a5c6-13c1-7b31-80d4" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="ffd2-4b9b-501f-d7b8" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="11bb-4e27-e797-fd46" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="65c6-53bc-6686-7490" name="Da Vulcha&apos;s Klaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c86f-8230-afed-dafc" hidden="false" targetId="9636d31c-6837-f767-9187-aefcc0470727" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d293-e84c-f830-795a" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="aee2-2548-68a9-6755" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="61cc-a5e6-cbb5-7f27" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6e80-6706-1b66-9ddc" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3c29-b96f-ef6b-63eb" name="Rokkit Pack" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="acba-7fd7-d493-d7c0" hidden="false" targetId="00b19c1b-2e18-0f04-52df-aeb27c8d139a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3e6f-2de8-9f5b-8116" name="Choppa" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="2b3b-804e-7dd0-3666" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e143-8244-819a-5dcc" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0683-379f-4bef-9e77" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="38d9-61c3-95b1-f71d" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
+            <entryLink id="38bf-7c33-3030-f191" name="New EntryLink" hidden="false" targetId="1fd7-fda0-aa69-d4d3" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -20365,12 +16559,8 @@
               <constraints/>
             </entryLink>
           </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="65.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="e5b5-8d41-93ae-a018" hidden="false" targetId="199a26c2-88ac-f821-c1c0-53f52e909d28" type="selectionEntry">
           <profiles/>
@@ -20378,6 +16568,16 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+        <entryLink id="4f8b-d8ae-ef21-8c59" name="New EntryLink" hidden="false" targetId="617b-779d-5627-57b7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bacc-27e2-03e3-5932" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22cf-d187-7409-3264" type="max"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>
@@ -20463,278 +16663,11 @@
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4a7bc38-f85c-0552-d50c-cf3640222184" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="396d-deac-6f81-47d9" name="Deff Dread" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="cbd1-27fd-9449-4521" hidden="false" targetId="e108654d-936f-47e0-f1b8-85a2957bef11" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5f22-2301-60a8-d9c0" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8784-9fc8-b051-ed36" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="8f4c-cc3e-4b68-0c56" name="May Choose Any" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="c81b-3ad8-3c39-fd66" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="e169-ddea-9ba3-288e" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f361-b876-09db-ee64" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="ee80-0e89-4d21-bbae" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="23b8-4b21-ecfe-b925" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="05c9-3532-49f6-6a87" hidden="false" targetId="056f-0d8c-4617-6065" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="80.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d3d2-e5ae-e25b-10d0" name="Killa Kans" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1c3a-fa9c-543a-26c2" hidden="false" targetId="5cd704ba-04d7-96c1-17fe-be4fb093117c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="10cf-7311-86e9-0e2f" name="Killa Kan" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="22ac-9fbd-f904-6baa" hidden="false" targetId="c798f715-ec69-02f8-aaf3-ff7bc3171cf2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="15e6-a0c2-9b04-cc08" name="Kan Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="fc33-fbfd-407c-17c6" hidden="false" targetId="07f43816-45a2-2e82-d805-1c603ef2c5b5" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="c325-373e-16ee-a4d2" name="May Choose Any" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="9bfa-aaf6-b59d-e025" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="a6bd-8e44-a12d-0908" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="49b8-c88b-d47c-254b" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="38ca-2ad5-37ae-c796" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="43ee-bd96-d0e7-bd3d" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="fa10-ae37-3293-d521" hidden="false" targetId="03be-c490-b054-b185" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="0f9e-9b93-d80f-2732" name="Must Choose 2" hidden="false" collective="false">
           <profiles/>
@@ -20776,14 +16709,56 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="994d-998b-13c1-27fb" hidden="false" targetId="76d885d1-61ae-138e-9d56-151523fd1e55" type="selectionEntry">
+            <entryLink id="994d-998b-13c1-27fb" hidden="false" targetId="9e55-1c56-22d9-3e01" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="a4cc-58fd-3f43-b3c8" hidden="false" targetId="372b-1513-7e47-91de" type="selectionEntry">
+            <entryLink id="a4cc-58fd-3f43-b3c8" hidden="false" targetId="dc4f-2ba9-0af5-304d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3954-5381-57b9-6287" name="Deff Dreads" hidden="false" collective="false" defaultSelectionEntryId="b036-653a-fbe3-197f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752b-166f-bba0-b373" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea1-6657-2f3c-9497" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b036-653a-fbe3-197f" name="New EntryLink" hidden="false" targetId="af54b56d-02bf-9cc3-16da-99944a168e89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4bfb-3a1f-98e5-332f" name="Killa Kans" hidden="false" collective="false" defaultSelectionEntryId="7950-9204-97d5-0c9e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0b1-b03e-63dd-27a6" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2553-6631-d84d-298a" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7950-9204-97d5-0c9e" name="New EntryLink" hidden="false" targetId="28a6-3572-7007-29e6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -20850,1326 +16825,30 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="ca03-ecb9-9759-1c24" name="Meganobz" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9354-68eb-f44e-535b" name="Meganobz" hidden="false" collective="false" defaultSelectionEntryId="8197-a0a3-08bd-3801">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="87e6-8fdd-630b-ebf4" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="4b29-f450-728d-8da8" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="ce40-1e8e-733d-600a" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="081f-6efe-8a3e-707b" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f01e-4e68-e459-731f" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="6345-a2da-8f30-18e2" name="Dedicated Transport" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8197-a0a3-08bd-3801" name="New EntryLink" hidden="false" targetId="7b919608-1731-c4b0-4112-ddc5d867a11f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="1528-256e-1c17-9094" hidden="false" targetId="8ea5c639-80eb-bf9f-0194-8033746e1f42" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="d203-a621-2f99-0a15" hidden="false" targetId="e52a209b-b0ff-5b42-5478-981eb7ab6808" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="6ddb-9ad5-91d5-4233" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="4eda-f711-db7d-2acd">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="4eda-f711-db7d-2acd" name="Meganob w/ Twin-linked Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="2f6d-8a04-7971-56b2" hidden="false" targetId="be46c6f5-ee61-4dde-4a4e-16c0ba77687c" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="ce1c-1173-74f0-a174" name="Twin-linked Shoota" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="77c7-3174-5ab2-5cac" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="9a6d-a988-b3a3-f183" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="d942-5821-2722-dfc3" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="1a80-eafb-535a-56bc" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5830-3a55-2477-8140" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="b51c-2898-1e73-118a" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="2ec5-3df9-d33e-0746" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="47b6-8197-c80f-1f7c" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="c7c4-1a4c-6533-797e" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ea27-fb85-45c5-01ef" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="ffcd-35cb-4ece-7f4d" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="40.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d8ad-2952-b048-8dbe" name="Meganob w/ Kombi- Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="a1cd-7487-7993-1221" hidden="false" targetId="be46c6f5-ee61-4dde-4a4e-16c0ba77687c" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="7c7a-5d09-a76d-4466" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="76e6-61cd-3691-0871" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5e6c-797f-9fe1-7994" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="55dc-f8ff-e30e-ca42" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="e1b9-7380-f405-a2ac" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="fb51-a524-7f11-c36c" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="cc27-1c88-0a7e-c871" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="173a-0e7d-5e4f-7c45" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="439a-1b4c-6835-fd8a" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="e906-f112-79db-54f9" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="dc15-ae24-0d44-1f26" name="Kombi-weapon w/ Rokkit Launcha" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f7d6-3029-db68-4bd5" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="3f79-4c2b-57ea-31fd" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="a752-684d-c6cc-ecf6" hidden="false" targetId="3a5e5b32-bf2f-ad9b-4d15-4070f6ccf6bf" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="45.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f716-9be1-0e10-cf8b" name="Meganob w/ Kombi- Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="345d-4a17-4812-001e" hidden="false" targetId="be46c6f5-ee61-4dde-4a4e-16c0ba77687c" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="fd38-be7d-2c6d-c15b" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="c6e1-4d8d-828a-ade8" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="a0df-283b-0216-9d04" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="4df3-bb12-83c1-b718" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="f65c-b586-565b-29a5" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="1060-f24e-4324-31c9" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="817c-aab3-ab12-efcd" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="8130-2974-71ca-e99a" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="0676-139a-f489-1ad8" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="ac96-1aca-b3cf-2936" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="72d9-d15c-2817-27a1" name="Kombi-weapon w/ Skorcha" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="b99c-2376-62fc-34d3" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="9dc9-1d46-30c2-f65f" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="cf07-8c1d-e0cb-51e3" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="45.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="eb56-b167-f602-6a2a" name="Meganob w/ Killsaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="8881-9592-7e5b-bb68" hidden="false" targetId="be46c6f5-ee61-4dde-4a4e-16c0ba77687c" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="2f34-906b-9372-4594" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="8c1b-b9aa-8469-416e" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="fe8a-de2f-d0cb-ca4b" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="9514-244c-1d5c-0687" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="3268-f444-cf2e-1457" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="c3c4-c6a7-e63b-c17f" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="c4b7-98c0-6abd-3616" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="206e-b96d-91fc-c1fe" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5359-4770-c525-5cb4" name="Killsaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="49af-50e9-1d60-ba41" hidden="false" targetId="0e4f3e53-4dae-120f-149e-8cc799313b51" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="50.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="2c2c-7995-698a-a44f" name="Boss" hidden="false" collective="false" defaultSelectionEntryId="a7f8-70e1-c373-f0a6">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="a7f8-70e1-c373-f0a6" name="Boss Meganob w/ Twin-linked Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="bd14-ef06-bf95-78e1" hidden="false" targetId="0f827618-d9a7-78d7-97b7-1023245fe358" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="b3f4-b9db-c6fc-e82c" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="b807-7d69-23b4-afca" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="499f-a905-0145-7b3c" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="052e-18c8-3e56-8ee3" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="794b-e2ab-81cd-da22" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="cfe8-f4c6-857b-55a8" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f5f3-5d20-ae95-cfb4" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="cc1e-ce72-854e-0fc9" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="47c8-90b3-bfe6-f4e7" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="ba08-8224-5873-721a" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="d88c-0cc5-e630-b6c9" name="Twin-linked Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="c8a9-a01a-3515-d750" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="a215-b09a-4846-364a" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="40.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8f68-305c-caf4-1b8a" name="Boss Meganob w/ Killsaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="71d8-1fc7-98c0-0f6a" hidden="false" targetId="0f827618-d9a7-78d7-97b7-1023245fe358" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="fa38-89ad-6789-f91e" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="e935-e241-bc60-c737" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="38d0-7404-7ab1-896d" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="927f-46a2-5558-5ea0" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="5fc5-5f84-e26d-bba6" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="44cd-2388-a932-6342" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="9f1d-138f-8a25-004d" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f72e-d31a-8489-68cb" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="202f-1a10-c618-675e" name="Killsaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="03e8-57b6-04a5-6d48" hidden="false" targetId="0e4f3e53-4dae-120f-149e-8cc799313b51" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="1ca0-2b3d-4a26-8d2e" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="50.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="a7ce-a77f-7d04-8f08" name="Boss Meganob w/ Kombi- Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="657a-af42-4e55-b977" hidden="false" targetId="0f827618-d9a7-78d7-97b7-1023245fe358" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="ee49-97c7-9871-939c" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="af66-390c-5cb0-44ad" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8a3d-275b-21a2-d86e" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="944a-a84b-ed3e-3e13" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="2638-1f6e-3504-b700" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="7014-ab82-46f4-95b2" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8922-0c2c-844e-a9ab" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="87b9-bbcc-2cc2-ba09" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="86de-16e6-ba34-bf6d" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="aa36-257c-258c-0fa0" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="4193-421b-aafc-b244" name="Kombi-weapon w/ Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="3bfe-41ab-39b1-c416" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="8317-acf6-fe23-5e1e" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="7b05-0d48-e1ff-759c" hidden="false" targetId="3a5e5b32-bf2f-ad9b-4d15-4070f6ccf6bf" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="6f71-b55e-7772-87a6" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="45.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="add6-f622-6337-b9fb" name="Boss Meganob w/ Kombi- Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b5b8-5c95-a4fc-13a1" hidden="false" targetId="0f827618-d9a7-78d7-97b7-1023245fe358" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="ad4b-3b83-3d53-9acb" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="b0e6-c918-56c4-c0cf" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="83c2-0884-f1b6-a30a" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5504-461c-2e43-4351" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="76c8-1ed3-aa5a-84ec" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="c98e-b2da-ad11-666e" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="e82b-a145-a65f-f743" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="d7e2-f85b-edcd-2be6" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="a567-8e20-a771-a480" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="4659-fd9e-9c98-a21f" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="a7dd-e19b-5749-2bd1" name="Kombi-weapon w/ Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="a1fc-dcf4-837c-4054" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="b52a-ce35-389e-af8e" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="e7e8-df23-782b-3a48" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="f38b-be9c-a0a7-1fc8" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="45.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="bd4d-9ef5-d4dc-527d" hidden="false" targetId="199a26c2-88ac-f821-c1c0-53f52e909d28" type="selectionEntry">
           <profiles/>
@@ -22200,485 +16879,11 @@
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4a7bc38-f85c-0552-d50c-cf3640222184" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="a9ee-b4a2-7af4-e31c" name="Killa Kans" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ea44-d0d4-005f-e3c8" hidden="false" targetId="5cd704ba-04d7-96c1-17fe-be4fb093117c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4bda-8211-b2a2-ec57" name="Killa Kan" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4d2d-32a0-1262-2564" hidden="false" targetId="c798f715-ec69-02f8-aaf3-ff7bc3171cf2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="ab28-94e6-0a43-8e13" name="Kan Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="3a54-ff73-5094-6eef" hidden="false" targetId="07f43816-45a2-2e82-d805-1c603ef2c5b5" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="351d-77c7-72c5-97b7" name="May Choose Any" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="7661-9271-0be5-af76" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="ce3a-6c85-2634-d146" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="047b-555c-ffdf-c61d" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="bfd8-9268-86f0-7bdb" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="4105-af24-d4dd-6e87" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="23e3-b5da-a453-4ceb" hidden="false" targetId="03be-c490-b054-b185" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="95b7-b1e7-c9da-b185" name="Gorkanaut" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="38e3-acf1-5310-e58b" hidden="false" targetId="3fcf90f1-7d84-9885-d3ed-5a91c18f70c3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="91b5-c02c-ef1c-fb35" hidden="false" targetId="814f-6a54-47ae-6abd" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="2df9-56cf-a056-e13b" name="Deffstorm Mega-shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="447d-6e98-8c8c-b265" hidden="false" targetId="d8b2f601-e624-349d-5985-7d32756134da" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d4ab-30dd-2029-f8b6" name="Twin-linked Big Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="bbbe-a12a-233e-62ef" hidden="false" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d2ee-7e45-c977-b4ac" name="Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a800-577b-a045-f45b" hidden="false" targetId="076b7eee-123d-6d81-3099-053319f2ada6" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6b31-12a6-b5a5-cf3a" name="Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4061-7f87-e5c1-21bf" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b515-02dd-6670-d8fc" name="Klaw of Gork" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7116-fd04-886b-01f0" hidden="false" targetId="23efc370-3fc7-63b2-1269-7c054427b0d3" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="14f6-180a-e204-6c39" name="May Take Any" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="ac34-d723-3387-6f18" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b0fd-8097-fd4f-1f63" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b14d-2b10-00aa-2c94" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="8943-6a74-7161-0f29" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="7873-d6e4-0c69-acf4" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="245.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8f43-f101-154a-e452" name="Deff Dread" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="36a9-642c-3e70-a23f" hidden="false" targetId="e108654d-936f-47e0-f1b8-85a2957bef11" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="0a12-fe87-b87c-77ce" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d62c-257f-d492-1e22" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="00ca-10ae-2c49-e81a" name="May Choose Any" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="68ce-700b-2f7b-4135" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="0d2d-064f-0de2-13b2" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="45cc-b2cd-8d47-f39f" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6ba7-254b-efac-4df0" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="9811-6f79-c986-39b2" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="b6ae-df0b-b9a8-3b70" hidden="false" targetId="056f-0d8c-4617-6065" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="80.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="2e2c-c970-f546-bffe" name="Boss" hidden="false" collective="false" defaultSelectionEntryId="9c3e-281c-2c9d-53c4">
           <profiles/>
@@ -22689,259 +16894,17 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="c4a4-3df8-ea36-3295" name="Grukk Face-Rippa" book="Sanctus Reach: Stormclaw" page="24" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d59e-cd71-905a-4d91" hidden="false" targetId="84fad7f5-25bf-cf10-ac8c-d2350aab0eb6" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="4f4f-8b8c-98b9-eaac" hidden="false" targetId="beccfd4d-727c-b85e-2bc7-82d4855fc906" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="11db-fa31-3ddb-72c7" hidden="false" targetId="3c4b757d-bd20-642e-9324-7e9012713139" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="4bc2-f58a-3748-0677" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ef2c-8fd5-274a-9b70" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="a046-d762-d02d-c0ca" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="b73c-9ea2-fb6e-fc0a" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="1bd8-fdce-e8f8-a13a" hidden="false" targetId="3c7d-11d6-e265-abb4" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="maxInForce" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="81469f58-865c-62c1-5fda-313427846b1d" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="3f47-4b31-4f74-0589" name="Gift: Git-rippa" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="7558-0784-0901-54bd" hidden="false" targetId="4b12108c-6d9b-5b6d-bfa8-4f0faf583f93" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                    <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="4c95-d2c4-d9a6-5e01" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c041-e0ba-af86-8d5e" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b956-b35e-3c84-5a8a" name="Kombi-weapon w/ Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1ab5-2b37-3707-63f0" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="72ff-6cac-1c12-5978" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="f1e7-cf1d-92aa-23d6" hidden="false" targetId="3a5e5b32-bf2f-ad9b-4d15-4070f6ccf6bf" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="668a-7e29-759a-0a48" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c5f5-de82-2c5b-a457" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="bee3-f483-425e-d626" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="4fd7-5bd8-fd6e-4f92" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f199-0a83-3c99-5ff8" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="57b3-67b8-d94a-f572" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="bab3-3017-54a2-0f4e" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="f838-7136-c8b9-9cfb" hidden="false" targetId="a9d2-7495-983f-54a6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="130.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="9c3e-281c-2c9d-53c4" hidden="false" targetId="a051-8109-fd9d-b174" type="selectionEntry">
+            <entryLink id="9c3e-281c-2c9d-53c4" hidden="false" targetId="24ba-2ca9-5ae8-b5ff" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="ce77-b045-0105-4e24" hidden="false" targetId="89d5-f953-1c6d-4322" type="selectionEntry">
+            <entryLink id="ce77-b045-0105-4e24" hidden="false" targetId="6cfa-d1ae-de1d-24d0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -22949,6 +16912,13 @@
               <constraints/>
             </entryLink>
             <entryLink id="2f63-c74c-7254-dc75" hidden="false" targetId="dbd3-3d18-187f-487a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2c3b-3eea-54ad-76b3" name="New EntryLink" hidden="false" targetId="81469f58-865c-62c1-5fda-313427846b1d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -22966,469 +16936,59 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="3816-b2fe-a460-06b8" name="Skrak&apos;s Skull-Nobz" book="Sanctus Reach: Stormclaw" page="26" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="ca9d-b6ef-4744-aee7" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="6c04-24de-9bd5-3dbb" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="0332-a0c3-38ec-5681" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="a2bb-591a-8f1b-8e5e" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c4a4-3df8-ea36-3295" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="c141-006c-ef4f-84b4" name="Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c4f6-0289-2361-c114" hidden="false" targetId="c8a567d4-7dba-6220-fd44-d285bbb931af" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="5654-debc-d095-a137" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="c2be-e894-7e86-8e56" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f886-1aa2-cd09-8ceb" name="Choppa" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="498b-3ad1-1046-bd40" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="c7fc-5c10-1774-63f3" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="d4d9-176c-081a-fc7d" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="e379-4787-9a29-8a60" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="09a7-ed3f-71ed-b11a" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="473d-89df-9419-4da3" name="Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="16bc-85c8-eca6-0a0a" hidden="false" targetId="c8a567d4-7dba-6220-fd44-d285bbb931af" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="a865-66d6-12ce-f99f" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="0a9d-2e4d-472e-eda7" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="426e-73f0-96c6-18f8" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="15c6-5e2d-5e7a-b403" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="fe90-d2fa-577e-ff08" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5ebc-1dca-2d49-6f1a" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="bf4a-e359-040a-353c" name="Kombi-weapon w/ Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="81b7-d95f-de49-963c" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="0647-70ba-322b-fa87" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                        <infoLink id="d0e8-3e6d-e3a4-0bd5" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="7da3-e55d-6714-ff93" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="23bc-e625-3fb4-3037" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="3690-ce1d-c75e-b90c" name="Nob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="62ea-8ff8-7e5d-a2ea" hidden="false" targetId="c8a567d4-7dba-6220-fd44-d285bbb931af" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="563e-0540-4be9-e226" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="c324-42da-c876-71ca" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f04a-8cb2-e2a1-6206" name="Slugga" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="7965-0dea-afc8-81ae" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8aea-1fea-0f59-3a71" name="&apos;Eavy Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="a746-6fa0-6392-1424" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5838-2735-dc44-04f7" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="adba-aa9b-08a4-4892" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="3cde-c5d8-e6be-87ae" name="Bosspole" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5821-adb0-d15f-1efb" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f18d-2ca9-5d1e-aa06" hidden="false" targetId="f765-c218-70eb-89bb" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="190.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="cd44-9310-5a15-1fc7" hidden="false" targetId="632cf00b-e88d-4c00-d57e-8965f2ad805b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="17d1-6609-1d59-9fa6" name="New EntryLink" hidden="false" targetId="d9f84ca5-9280-f052-de9e-4ee0952bd82d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="407e-81d1-c95e-f82a" name="Deff Dreads" hidden="false" collective="false" defaultSelectionEntryId="c571-eec5-1a18-0615">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6308-49c1-80eb-dae3" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1ed-4a6c-dbd6-5710" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c571-eec5-1a18-0615" name="New EntryLink" hidden="false" targetId="af54b56d-02bf-9cc3-16da-99944a168e89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7bce-0968-6b10-06c0" name="Killa Kans" hidden="false" collective="false" defaultSelectionEntryId="6fd4-b065-9db2-0e2a">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8160-32f5-8c29-2b94" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="540e-b674-43f1-f278" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6fd4-b065-9db2-0e2a" name="New EntryLink" hidden="false" targetId="28a6-3572-7007-29e6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -23456,6 +17016,16 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a28-dd43-1455-9e69" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="e653-88dc-11b7-789d" name="New EntryLink" hidden="false" targetId="3db44014-0525-4550-f018-cabf08517723" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="486c-ad3f-5910-47e6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0304-1f07-03f9-ff1e" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
@@ -23474,222 +17044,30 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="4bce-646b-839d-b88d" name="Gorkanaut" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="384a-9486-820c-7c7f" name="Gorkanauts" hidden="false" collective="false" defaultSelectionEntryId="e7ec-2c8c-868e-e8a0">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="8793-019a-e32d-25c3" hidden="false" targetId="3fcf90f1-7d84-9885-d3ed-5a91c18f70c3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="67bd-0a09-e033-dca0" hidden="false" targetId="814f-6a54-47ae-6abd" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="fa75-63b9-e8a5-cc92" hidden="false" targetId="f21a-defd-6f45-5536" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b1-0802-d050-9ea8" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a50f-81ed-68ef-0789" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="4a5b-3243-d134-ecb5" name="Deffstorm Mega-shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="70e2-fdf0-e684-f318" hidden="false" targetId="d8b2f601-e624-349d-5985-7d32756134da" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c0af-339d-5120-8fd7" name="Twin-linked Big Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8a10-46d8-1e2e-0ad2" hidden="false" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="580a-69a1-4e42-9bf3" name="Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="f7ae-8948-3019-f3c3" hidden="false" targetId="076b7eee-123d-6d81-3099-053319f2ada6" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="12d7-023c-126b-af0c" name="Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="555b-6256-0054-135f" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1678-4517-ccaf-6818" name="Klaw of Gork" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c3cd-7e60-4588-b57b" hidden="false" targetId="23efc370-3fc7-63b2-1269-7c054427b0d3" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="0edf-413b-dbbe-169e" name="May Take Any" hidden="false" collective="false">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e7ec-2c8c-868e-e8a0" name="New EntryLink" hidden="false" targetId="3db44014-0525-4550-f018-cabf08517723" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="26cb-090a-9a1e-1cde" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1d5e-c6a4-d560-d8f4" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="4596-2846-5117-e0d1" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b219-edb3-97ba-5626" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="901c-b8d0-4350-5a50" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="245.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="0c0d-0ad1-74d3-c253" hidden="false" targetId="199a26c2-88ac-f821-c1c0-53f52e909d28" type="selectionEntry">
           <profiles/>
@@ -23722,335 +17100,30 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="f2f2-b03a-8aed-3d51" name="Flash Gitz" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3b0a-606f-1071-1b1b" name="Flash Gitz" hidden="false" collective="false" defaultSelectionEntryId="c1aa-0aa7-1899-c81b">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="267f-967e-76d0-5835" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c5db-f31d-f235-68bf" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="6dd8-4cd4-f1d9-4ec4" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9244-2243-f925-ecec" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed3-c9a5-b6af-674c" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="54bc-d659-1f4c-7d40" name="Flash Git" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="fb6c-91a5-9012-e5b4" hidden="false" targetId="07df7a33-0848-3745-f3eb-5566fc5ddbc5" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="f7f7-1a1a-47c2-8c3b" name="Snazzgun" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="911c-f81e-c6c1-2a11" hidden="false" targetId="03a9b62d-babd-eaeb-6bd9-3cd92cb85061" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="0cd8-2045-5f65-3c3a" name="Gitfinda" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="8d1d-c579-e2a3-2540" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1ef8-8e61-7f83-641d" name="Bosspole" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="e3af-639d-3262-571c" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="255e-a82c-91bb-f5e3" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="ed8a-03d3-f205-c8bb" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="22.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7479-b4a0-a7a9-f79b" name="Kaptin" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="aa77-0d41-895d-7d6c" hidden="false" targetId="f7974aae-5db0-22f1-ded1-581a02f8f8c1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="eba7-f5b6-be16-44a4" name="Snazzgun" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b7e1-8027-035f-e3f7" hidden="false" targetId="03a9b62d-babd-eaeb-6bd9-3cd92cb85061" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="6012-2697-3394-3784" name="Gitfinda" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="bf3e-5b80-6a6c-cbd6" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8ded-6e48-a00c-bf3f" name="Bosspole" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1b8f-5a25-2523-25c6" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1af7-e8d4-303a-bd7a" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="a4dd-2fa2-0ce7-f7b6" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="7553-492f-0610-1783" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f8a8-fd5e-e019-4e30" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5f8b-afed-87b1-3c0c" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="ab54-cfcc-4b1b-6905" name="Dedicated Transport" hidden="false" collective="false">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c1aa-0aa7-1899-c81b" name="New EntryLink" hidden="false" targetId="2e62-dfb8-5170-a190" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="621b-73cd-f194-06ec" hidden="false" targetId="8ea5c639-80eb-bf9f-0194-8033746e1f42" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="46b2-4b02-93df-733a" hidden="false" targetId="e52a209b-b0ff-5b42-5478-981eb7ab6808" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="22.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="71f9-f3e7-d84c-208b" hidden="false" targetId="0a19c8c3-a718-82bf-4d41-da12b53c9edb" type="selectionEntry">
           <profiles/>
@@ -24138,14 +17211,14 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="d144-4a51-4e9e-083b" hidden="false" targetId="a051-8109-fd9d-b174" type="selectionEntry">
+            <entryLink id="d144-4a51-4e9e-083b" hidden="false" targetId="24ba-2ca9-5ae8-b5ff" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="6f0b-1094-6568-6d72" hidden="false" targetId="89d5-f953-1c6d-4322" type="selectionEntry">
+            <entryLink id="6f0b-1094-6568-6d72" hidden="false" targetId="6cfa-d1ae-de1d-24d0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24168,7 +17241,10 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3241-4a3b-60dc-0fa4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6086-307f-02a1-d4e9" type="max"/>
+          </constraints>
         </entryLink>
         <entryLink id="c1bd-3700-12cc-3f8e" hidden="false" targetId="0049-e47b-76d1-6824" type="selectionEntry">
           <profiles/>
@@ -24246,13 +17322,22 @@
       <constraints/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7b2ab538-5954-e40a-2e00-fc15f75c4eeb" name="May Choose 1" hidden="false" collective="false">
+        <selectionEntryGroup id="7b2ab538-5954-e40a-2e00-fc15f75c4eeb" name="Ram or Rolla" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="4581-7a70-8ac8-ea7c" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d08-8ab0-4c55-fec7" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4581-7a70-8ac8-ea7c" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="09f117c3-3db8-2cbf-99e5-a7745b2e43ad" name="Reinforced Ram" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -25139,6 +18224,8 @@
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab7e-2398-aba4-b734" type="notInstanceOf"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8a1-332b-08b0-133b" type="notInstanceOf"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a8be-6faf-78e5-8ab8" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c0d-3767-24c8-f20f" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ad2c-5c94-a003-c248" type="notInstanceOf"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -25226,522 +18313,6 @@
           <constraints/>
         </entryLink>
         <entryLink id="e0c4-e4b0-965b-e4fc" hidden="false" targetId="abe2-a292-d583-1681" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="35.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="76d885d1-61ae-138e-9d56-151523fd1e55" name="Big Mek (WG)" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="fd732325-e60e-ce79-aa8f-5e1e251e04d2" hidden="false" targetId="f63eae13-a4e3-062d-1c26-dc589b7d327f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46fb0bc0-23de-aa24-8f30-aa842a72e88f" type="equalTo"/>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fc04-0423-be94-2f67" type="equalTo"/>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bike (Character)">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46fb0bc0-23de-aa24-8f30-aa842a72e88f" type="equalTo"/>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46fb0bc0-23de-aa24-8f30-aa842a72e88f" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="eb339ba7-855c-f9bd-de83-cce49bf34463" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3bf68014-8127-28a0-af06-979fbbe88ea6" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="305ef848-dd86-5b7d-af33-11087b4e70c9" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="54b3c7b0-e383-1f87-e44f-dc66e989ab3e" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="1225bef9-6044-1afe-9067-db896a66bd2a" name="Mek&apos;s Tools" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="392d29c2-4667-137f-e464-07557ebbedae" hidden="false" targetId="c0eff1d5-cadd-e3dd-37c1-aba29f3b0981" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="06d6c814-5b5e-9588-43c9-b3c8863a7166" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d6c7011e-a867-fb08-0bce-ff0aad60e171" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="fc04-0423-be94-2f67" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="863e-6be2-1852-82cb" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="4.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="06654e02-14ff-6737-d038-7c37c8f61ac4" name="May Choose Any Runts, Squigs &amp; Know-wots" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="de0d1b4b-ff3b-8629-4787-5f74f0f4428c" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6af73ca1-e30e-ec9b-50f1-f03681d33c82" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="d3081d8e-9b06-5c94-4e12-a161405c8ed1" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1aebb02a-3a31-475e-aa47-eaf5b81c7600" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8c5f98ba-458d-d148-f940-87f67117def3" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ad8ad256-8e7f-de69-c691-4d46e67a89f2" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="494e4c8b-2e40-a864-9644-198fbe4dd6a3" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="089901fa-2254-5d24-966d-5e1dc224b914" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1cb707fc-09f7-46a6-81ba-c0c718d257b7" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7aa21743-8492-fbb4-3305-56ce411bd268" name="Grot Oiler" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="27580d7e-b12c-19ac-69e7-f8be4d65b26d" hidden="false" targetId="00ef1771-0e1f-2421-6e41-cd9f17d00645" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="152ae7f9-4edd-073e-4048-2f52e06c8377" name="Gitfinda" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1211b740-fe3e-4032-d0f6-39556af215a7" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="46fb0bc0-23de-aa24-8f30-aa842a72e88f" name="Warbike" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="716d705b-f26a-29bc-1577-ed330d086bf9" hidden="false" targetId="7d37a85a-e247-b485-63de-99099729b08f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="c8225b69-ebb0-724f-cf3c-237068d23f31" name="Twin-linked Dakkaguns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b65ce053-ed82-f446-fffc-a2607d135d05" hidden="false" targetId="eaa8e75b-082b-e14a-5e96-b7e729646618" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="bc3cc199-61ea-058d-20ee-21da352ef287" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="532bf6ad-cee9-af31-e27a-f0015daa41a2" hidden="false" targetId="fabc01fe-56c9-d819-a574-1c362bc702cd" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="b330cbaa-89d0-736f-1dc0-f7ae6a685552" hidden="false" targetId="599efb0d-5ca0-a20b-e052-05073a2a2c6c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="676a0dc6-bf49-7546-3740-4c8d7202d91f" hidden="false" targetId="c574a454-71f8-c18f-d43f-6af72311ee11" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="c3c31f97-1ca4-70eb-0580-5e7cbc35a51f" hidden="false" targetId="de54d4cd-6483-9424-6f35-200c3e61a859" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="743af5b5-c241-a08a-3897-286ad099b8fa" hidden="false" targetId="216c3599-d3f7-eae7-674a-c9535b05a44c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="1d390c5a-570a-2a0b-f2c5-783ac64fdfe9" hidden="false" targetId="e5f3e3d6-49b9-6d71-1a03-8cd2af8554f8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f388-e342-9635-8314" name="Gifts of Gork and Mork" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b4cd-4896-f0b6-cf41" hidden="false" targetId="25030daf-4eef-f5b8-4515-9860fe363438" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="d61a-543d-3668-dbd7" hidden="false" targetId="e8082e4a-deaa-4284-de95-d0b0bb9be10b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="322f-0f5e-6c97-60f7" hidden="false" targetId="30cc6165-7121-a4c0-1262-e729b435b68f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="9d80-7189-6c5a-4164" hidden="false" targetId="e1874b1b-7ca5-7fe1-5329-a0e073b0c230" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="a5e7-aaa0-b822-1856" hidden="false" targetId="c0773bfa-69cd-5e61-7d16-35180db73f6e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="beb1-8d7b-e225-ccda" hidden="false" targetId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46fb0bc0-23de-aa24-8f30-aa842a72e88f" type="equalTo"/>
-                        <condition field="selections" scope="76d885d1-61ae-138e-9d56-151523fd1e55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c43c4210-b493-689d-18df-cce4a5406287" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="8ce5d607-bce0-95cf-1202-cfa554b77dba" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="e87502a5-4bba-29a7-328b-93b1e571952d" hidden="false" targetId="c43c4210-b493-689d-18df-cce4a5406287" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="2fe2-f842-0803-1fee" hidden="false" targetId="0d9f-8f53-3919-0bd0" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="8e30-e06d-8628-2e43" hidden="false" targetId="abe2-a292-d583-1681" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="a0c3-0af9-d419-9aea" name="New EntryLink" hidden="false" targetId="a9d2-7495-983f-54a6" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -26397,20 +18968,22 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a0cb-a8b1-f9c9-c94e" name="Orkimedes&apos; Kustom Gubbinz" hidden="true" collective="false">
+        <selectionEntryGroup id="a0cb-a8b1-f9c9-c94e" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="false">
+            <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions/>
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8be-6faf-78e5-8ab8" type="equalTo"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8a1-332b-08b0-133b" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab7e-2398-aba4-b734" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab7e-2398-aba4-b734" type="notInstanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8a1-332b-08b0-133b" type="notInstanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a8be-6faf-78e5-8ab8" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c0d-3767-24c8-f20f" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ad2c-5c94-a003-c248" type="notInstanceOf"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -26554,514 +19127,6 @@
           <constraints/>
         </entryLink>
         <entryLink id="2f3f-8436-1fec-0c3c" hidden="false" targetId="aace-8396-c4bc-03e1" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="35.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="372b-1513-7e47-91de" name="Big Mek w/ Mega Armour (WG)" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="c2fa-cd23-0ca7-5a3f" hidden="false" targetId="f63eae13-a4e3-062d-1c26-dc589b7d327f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="372b-1513-7e47-91de" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="924c-b886-28e2-e98e" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="8fe8-b542-a966-640e" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="669e-99f0-e1bc-8f37" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="995a-0e40-a723-e990" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c660-b341-5ca4-a6a6" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="5bdf-72a0-674d-83f9" name="Mek&apos;s Tools" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1c15-cf00-417e-b502" hidden="false" targetId="c0eff1d5-cadd-e3dd-37c1-aba29f3b0981" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6fcd-99f4-58ca-4e12" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="252b-ac58-b784-3b49" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="924c-b886-28e2-e98e" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ac32-90a0-9858-55f2" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8629-8b3a-004b-79a8" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="bc43-aeaf-9bc2-293f" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f7c6-b56f-db6c-9ae1" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="555a-0755-27df-7325" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="240f-4f8a-d863-1a38" name="May Choose Any Runts, Squigs &amp; Know-wots" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="69b7-e904-0a87-9627" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="19f0-8708-859d-dbbb" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ba72-f343-98e0-27f9" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ef99-da06-16ca-fea9" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="301b-1f1a-b106-7830" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="40f1-3688-c816-615f" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a3ed-d365-188b-18ed" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="40e4-a134-2558-575b" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="2d7a-2fff-5a95-004e" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3aea-e3de-28c1-b3d4" name="Grot Oiler" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c790-acf9-2bdd-1d39" hidden="false" targetId="00ef1771-0e1f-2421-6e41-cd9f17d00645" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ac08-d8b2-5e7a-4ffb" name="Gitfinda" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="2d63-2eab-4cc0-d449" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8178-e6a9-ca24-d5cb" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="7958-43fa-2daf-ae64" hidden="false" targetId="fabc01fe-56c9-d819-a574-1c362bc702cd" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="d05d-bdf5-3af0-80e8" hidden="false" targetId="599efb0d-5ca0-a20b-e052-05073a2a2c6c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="c722-aa41-e032-b5a1" hidden="false" targetId="c574a454-71f8-c18f-d43f-6af72311ee11" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="6b9c-7429-9536-2f05" hidden="false" targetId="de54d4cd-6483-9424-6f35-200c3e61a859" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="0251-d85d-92e6-acc3" hidden="false" targetId="216c3599-d3f7-eae7-674a-c9535b05a44c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="d9b8-0566-54ea-5a58" hidden="false" targetId="e5f3e3d6-49b9-6d71-1a03-8cd2af8554f8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ea6c-372f-b451-0483" name="May Choose 1" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d616-4209-3376-297c" name="Kustom Force Field" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="f304-f6a6-2783-00d1" hidden="false" targetId="0af25ce1-419d-128b-d06b-f5bc2901990a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4f6b-162a-e82c-16d0" name="Tellyport Blasta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="bfd9-dfab-b5d3-f79d" hidden="false" targetId="8d68ccce-05f9-d4e4-13a6-0030e4cfc1fa" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ade9-9e11-43aa-e2c1" hidden="false" targetId="8d144d9d-8c27-a98e-ecaa-32b8be50513b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="13f3-2868-dd7d-2ee9" name="Gifts of Gork and Mork" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="77db-10d0-78a4-00d6" hidden="false" targetId="25030daf-4eef-f5b8-4515-9860fe363438" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="dc40-fc7f-16c9-f2e5" hidden="false" targetId="e8082e4a-deaa-4284-de95-d0b0bb9be10b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="6f25-9b34-0732-a6cb" hidden="false" targetId="30cc6165-7121-a4c0-1262-e729b435b68f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="0581-7fe9-72ef-7adb" hidden="false" targetId="e1874b1b-7ca5-7fe1-5329-a0e073b0c230" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="372b-1513-7e47-91de" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="ecab-113f-3e83-fcbd" hidden="false" targetId="c0773bfa-69cd-5e61-7d16-35180db73f6e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="a342-369d-0079-61d1" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="5372-b7f9-5c2a-4b95" hidden="false" targetId="c43c4210-b493-689d-18df-cce4a5406287" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="bbcc-a38f-cc1f-31b7" hidden="false" targetId="aace-8396-c4bc-03e1" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="5c21-fe84-7d79-0dcb" name="New EntryLink" hidden="false" targetId="a9d2-7495-983f-54a6" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -28322,7 +20387,15 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="465c-1336-3edf-ef25" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints/>
         </entryLink>
         <entryLink id="4b64-90ef-3718-3eed" name="New EntryLink" hidden="false" targetId="6fce-9698-40be-cf5e" type="selectionEntryGroup">
@@ -29606,7 +21679,15 @@
               <modifiers/>
             </infoLink>
           </infoLinks>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="minSelections" value="9">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2f15-0bd4-f43a-0fa7" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -33609,7 +25690,7 @@
         <cost name="pts" costTypeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="65fd-8ec3-3b86-6b61" name="Kustom Wazmob" book="Death from the Skies" page="151" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+    <selectionEntry id="65fd-8ec3-3b86-6b61" name="*Kustom Wazmob*" book="Death from the Skies" page="151" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
       <profiles/>
       <rules>
         <rule id="388c-cda5-f47a-2f39" name="Mega Kustom Force Field" book="Death from the Skies" page="151" hidden="false">
@@ -33647,10 +25728,7 @@
                 </infoLink>
               </infoLinks>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
+              <constraints/>
               <selectionEntries/>
               <selectionEntryGroups>
                 <selectionEntryGroup id="8d33-4335-f30b-e016" name="Wazbom Blastajet w/ Kustom Force Field" hidden="false" collective="false" defaultSelectionEntryId="10e3-048b-9018-678f">
@@ -34569,11 +26647,10 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7918-a9a5-a80d-517f" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3c88589e-9519-0db5-7e53-ccfa305a7bc9" name="Meganob w/ Twin-linked Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+            <selectionEntry id="3c88589e-9519-0db5-7e53-ccfa305a7bc9" name="Meganob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
               <profiles/>
               <rules/>
               <infoLinks>
@@ -34584,34 +26661,20 @@
                   <modifiers/>
                 </infoLink>
               </infoLinks>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="f06f-da90-51ad-f8cc" value="4">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24de-abb8-f0c6-f41f" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f06f-da90-51ad-f8cc" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="f3b21050-f320-4f56-0099-493fa9ec7b57" name="Twin-linked Shoota" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="803061ee-3576-994c-7fa5-8975703b09ba" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="6ce1e512-e29a-7667-3ab9-dcc3c17f26d8" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
@@ -34692,644 +26755,10 @@
                     <cost name="pts" costTypeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="15b30d05-99ec-ffed-e359-62d06aa88b52" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="d98aedca-1c9e-f6db-2b6e-5465cc6f58f9" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2933ac55-10b7-759b-157e-8ab93487582e" name="Meganob w/ Kombi- Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0a40e502-466d-a502-f1c8-d52f11a027f7" hidden="false" targetId="ef76ad11-a801-f688-7dec-b4a35b2830fa" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="745587b2-8b19-c5e4-8a2a-5dc67a3b6e0f" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="0d27f4be-fa67-36a2-0d56-b9d07d565a47" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5f87c03b-40e8-c371-27ec-bf4d4034e8db" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="f9203b40-56aa-905a-aea5-3d65165d6c44" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="c14aa7a4-e4f8-72d9-5b23-81a7753d9dbf" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="25e12163-26d9-c7ed-fa0b-44a8a9e46a90" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="bd1f8511-8e87-171d-ae1f-33b6f3b82e51" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="dc77d33a-afec-0286-c857-977b8438da3a" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="a46e90d3-f015-03e0-b4ff-97ade3ad896c" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="0177a4a2-79b6-768e-7dcb-9bb43aeb023a" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="21ca31a6-f69b-6ea2-60f6-48540208a473" name="Kombi-weapon w/ Rokkit Launcha" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="e040ee84-8e28-dced-fd59-9a5b941644ae" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="a42e79ef-a8d1-8003-9387-9e4527dc7491" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="363c2c15-f892-224a-dbe6-44edad94b81d" hidden="false" targetId="3a5e5b32-bf2f-ad9b-4d15-4070f6ccf6bf" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="45.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7e1b5813-84df-584e-d386-7a99644700b3" name="Meganob w/ Kombi- Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5ab9ad7e-4eef-27a9-114f-1daad3eb01f0" hidden="false" targetId="ef76ad11-a801-f688-7dec-b4a35b2830fa" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="8d8e545b-a760-203e-f79d-711166709f1e" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="7b188a0b-bed8-e6dc-76c1-4d82fb576986" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="edcf4ce2-db1b-db34-4afe-e382ff4e2607" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="0438d391-3163-fd5c-23ce-47fe03713dd2" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="dc24742b-07cb-7782-4f34-70e76e626d78" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="0f885d88-e5c5-43f2-37d6-f1d682056238" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="a6574db5-8999-a024-f818-55bcc637c441" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="fd5ec55c-22dd-ccc1-8234-9587588b2e03" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="221b382b-51ed-9ab4-dd55-2bcfa0ff9077" name="Power Klaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="239aba44-6c69-452d-f7b2-4580ebbe8466" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d84daaa1-86ac-18af-8da6-8f8267d208b7" name="Kombi-weapon w/ Skorcha" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="98e6da83-c246-6718-a5cd-21640ae22db8" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="7032b1d9-6177-48ae-221a-0508d9eb2d67" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="3ff3d0a9-1fab-aa24-e5f5-db4a16fb70bb" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="45.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="12bdb0ce-3a6f-34f1-d0c6-7cfa6a16ebd4" name="Meganob w/ Killsaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a9c828b4-864a-20bc-9193-74eb34078234" hidden="false" targetId="ef76ad11-a801-f688-7dec-b4a35b2830fa" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="bdbb4d67-4dee-123b-42b5-dd0357190608" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="adca95d7-8244-0e60-f154-6d32fe85ae52" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="9f39ced7-8ed0-95da-61cd-5e41d0a1eee6" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1b667eb4-5ffa-8ecf-385e-b4e1561e91ac" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="509d79bb-52aa-821d-716a-b965a0d4a08e" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="deeb6ba1-b4c0-115f-2f98-846ba17bd2be" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="19fc5ded-0a91-39fb-9eee-2885e2686707" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="3ff7bb64-9960-e52b-6ce7-f8e62740eb0d" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="25535070-b6d7-4509-558f-6d0971b96fa1" name="Killsaw" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="d5b5c88e-5d82-7e93-459f-215ceb51aa04" hidden="false" targetId="0e4f3e53-4dae-120f-149e-8cc799313b51" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5218c6be-c6ec-e871-c1c8-440996198e36" name="Boss" hidden="false" collective="false" defaultSelectionEntryId="56ec3dd4-b575-51a7-7392-3ffb9ebafa5e">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="56ec3dd4-b575-51a7-7392-3ffb9ebafa5e" name="Boss Meganob w/ Twin-linked Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="522a98f6-9b17-b4b5-ae9c-fce8f38957e7" hidden="false" targetId="d4502e4e-1b7f-4871-f95c-e9fe67c07c4a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="8d1ddfda-90bf-7562-cf59-639f9bcb5e9c" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="fff623d6-ade3-b4bf-13b3-051a7e9b00c5" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d0099158-2abc-b100-b57c-047fa39b03d9" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="870aa8ea-655a-1095-94f1-977dff1c0455" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="60aa4974-b880-9126-c7cb-32022f05a175" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="087212ad-fd1c-e69c-7858-0bedf1927383" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="4c9a447b-50c4-e72d-5993-c3b1810aef1f" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="45e49b66-a12c-8464-3042-9e055479b589" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="7478aa00-7ca2-112d-f10f-e289c56ed1ee" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="51bd2f4a-a787-54dd-f39f-d5741ab163ac" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="e44539f8-3e68-e88b-3cbc-58da159306c9" name="Twin-linked Shoota" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6ea1832c-e988-6b40-e2c8-9e956a20af04" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="f917c706-20a9-713c-6254-5765f7a7866a" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
+                <entryLink id="d458-9461-b9f1-7481" name="New EntryLink" hidden="false" targetId="687e-7590-5136-45a8" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -35341,11 +26770,11 @@
                 <cost name="pts" costTypeId="points" value="40.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="39c0e0b8-4619-9cef-08ab-e8104adc5174" name="Boss Meganob w/ Killsaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+            <selectionEntry id="a0ed-db48-d1c6-7c6e" name="Boss Meganob" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="eb771c64-437d-8b1f-4107-f25fd2c5fd27" hidden="false" targetId="d4502e4e-1b7f-4871-f95c-e9fe67c07c4a" type="profile">
+                <infoLink id="7564-6c51-7203-c120" hidden="false" targetId="d4502e4e-1b7f-4871-f95c-e9fe67c07c4a" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -35354,14 +26783,15 @@
               </infoLinks>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fa-b7c3-4093-fc6e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ba1-bc57-7a1d-6fba" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="7727703f-a2e8-6411-0e3c-95a725399ef6" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                <selectionEntry id="06f6-0bdd-3fb7-8dfe" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="449f2af7-fa40-1857-9ff9-2652ff04e992" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
+                    <infoLink id="1412-4a3a-4362-d795" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -35370,65 +26800,7 @@
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1b48ef5f-ca92-5506-5b29-b9ea957a7b3c" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="89f93a70-f279-7275-b1ca-5627266ca60a" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="811ec80c-a03b-831c-17aa-6a4b14fa987b" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="938db066-863e-9d99-c486-6fcb734d1ebe" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="ac64826b-d485-f3bd-8b1b-27faf14fd0ff" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b9e1db2c-7729-3694-4548-f6b0b0672eb2" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="81b2-abec-6fef-c781" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -35437,11 +26809,23 @@
                     <cost name="pts" costTypeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="cd3dfa4a-19d2-c771-5526-d9f97c3326db" name="Killsaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                <selectionEntry id="32a0-6be8-f0c3-1143" name="Mega Armour" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="2f86d35e-7031-35f6-bb1d-7ebae8408d56" hidden="false" targetId="0e4f3e53-4dae-120f-149e-8cc799313b51" type="profile">
+                    <infoLink id="1456-b56c-ad97-8c2e" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="3974-74a8-f1a2-b5f9" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="a840-0239-6830-58c6" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -35450,8 +26834,31 @@
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89c0-8384-06ca-d18e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a09d-c968-fb38-b9fa" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="de17-d9f6-63b3-b03e" name="Stikkbombs" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="d30e-b8ec-f841-e18f" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e415-b023-ff56-edc4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d8c-84b9-f404-dd8e" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -35463,7 +26870,14 @@
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="3536e1d0-1b59-6e61-ec21-0179e375a20e" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
+                <entryLink id="5870-1a73-5314-b626" name="New EntryLink" hidden="false" targetId="687e-7590-5136-45a8" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e5e7-e402-a538-c615" name="New EntryLink" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -35472,345 +26886,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7f744bbc-ae97-8d39-0da5-bcae591aec23" name="Boss Meganob w/ Kombi- Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d23f6975-a4ff-cb2d-6d43-15149ebebe0b" hidden="false" targetId="d4502e4e-1b7f-4871-f95c-e9fe67c07c4a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="3f9ed6e9-920b-dc02-0a7d-46dedaa9494a" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="edf925d7-489f-0149-c3fc-bb8bb8554cb0" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="60b1c85f-578d-8200-43bc-6985b07bb8ed" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="4e140375-fef6-26cf-254c-91dce6ffab88" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="6042d928-96b7-4240-ae23-ae224a59c550" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="09de39a2-bc3a-afd6-c691-ffb1e9af2bc7" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="9bc6dd2c-d146-0c3a-53b0-e7e6bbdee380" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1bbd4730-4bd6-a654-7259-89695795037f" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5c227238-56e7-a972-1313-326d1c5e419e" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="d4a1a4f5-444a-0069-7708-0ff14cb857f0" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b388c90b-0aa1-e174-6f62-975e5e884456" name="Kombi-weapon w/ Rokkit Launcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c369fe30-0a07-f5e5-5b97-d5ef2e1d786d" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="3dd961a5-7b53-8412-e1cb-9aee01b36d16" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="55e7ce25-884b-5399-6df6-613daa56af59" hidden="false" targetId="3a5e5b32-bf2f-ad9b-4d15-4070f6ccf6bf" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="5e3eb90f-2e35-f31c-e550-26851609149d" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="45.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="51a2b969-35bb-0cb6-51cf-f59e94b03ed6" name="Boss Meganob w/ Kombi- Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="fc5a0fd2-1a15-560c-23a6-5b4770642a81" hidden="false" targetId="d4502e4e-1b7f-4871-f95c-e9fe67c07c4a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="b0ac24a6-be27-6331-db72-59f8162187ee" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="dd9fdf6c-0c07-f9e2-9c2e-69855156bb49" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="de83a7c5-512c-243c-73e6-306090940d03" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="d1b82fc7-fe0a-afe7-dbaa-d2dac65f9999" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="7da9019e-5a87-c6db-f9aa-2fc2ae87aa4e" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="a17d8c87-efcf-8a8b-9626-cba2e041d28e" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="86ccdada-4325-e801-7162-85035134664b" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="544c7102-61b4-2501-7a97-91afc98cc964" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="a187d589-bd63-a62d-67e7-44f3c90e1804" name="Power Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="cb8b4213-daa5-6e24-2f4a-1ee15d27a808" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="acd1868d-6a87-e60c-6b90-ac144ee633e6" name="Kombi-weapon w/ Skorcha" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="abfc287e-3a16-6fa9-a3f0-899539977d9f" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="884e617b-db46-ae66-c432-fe184e8216c0" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="b01ed328-edb3-c789-fef6-814367261c26" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="df34e586-0de4-65c0-1e92-b387d00faefd" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="45.0"/>
+                <cost name="pts" costTypeId="points" value="40.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -35958,7 +27034,9 @@
           <constraints/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="46c55e93-cb83-23f5-7842-024b4fc8bb12" name="Mek Boss Buzzgob (FW)" book="Dred_Mob.pdf" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles/>
@@ -37711,9 +28789,18 @@
               <modifiers/>
             </infoLink>
           </infoLinks>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="6931-5723-cc5f-61a7" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c0d-3767-24c8-f20f" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6931-5723-cc5f-61a7" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -38173,7 +29260,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="46d5-1c7e-e29a-9005" name="Ork Skwadron" book="Death from the Skies" page="150" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+    <selectionEntry id="46d5-1c7e-e29a-9005" name="*Ork Skwadron*" book="Death from the Skies" page="150" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
       <profiles/>
       <rules>
         <rule id="8e1e-59b9-e8e3-56db" name="Best of Da Best!" book="Death from the Skies" page="150" hidden="false">
@@ -41452,6 +32539,10 @@
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8be-6faf-78e5-8ab8" type="equalTo"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab7e-2398-aba4-b734" type="instanceOf"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8a1-332b-08b0-133b" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c0d-3767-24c8-f20f" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2bb-591a-8f1b-8e5e" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0ec6-d007-89cf-1579" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="465c-1336-3edf-ef25" type="instanceOf"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -41525,449 +32616,6 @@
           <constraints/>
         </entryLink>
         <entryLink id="f53d-5b16-4b84-a28e" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="60.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a051-8109-fd9d-b174" name="Warboss (WG)" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="dab0-ef81-63d2-4d5e" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="30ff-e739-1327-40f9" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="413c-a615-dbb3-1a7d" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4462-2ef4-fb68-3e54" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="fdb8-075a-7ee7-537e" hidden="false" targetId="375f7f5f-99b7-cc4c-242d-7382b544b68f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b140-2b75-6c04-d4be" type="equalTo"/>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="67fe-b60e-da5c-7abb" type="equalTo"/>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Bike (Character)">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="67fe-b60e-da5c-7abb" type="equalTo"/>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="equalTo"/>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="67fe-b60e-da5c-7abb" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="1c8a-5c5d-125d-2372" hidden="false" targetId="3c4b757d-bd20-642e-9324-7e9012713139" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="3c60-b554-64cb-7c53" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="dc11-e788-a247-fa61" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b140-2b75-6c04-d4be" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5782-c934-3ed3-998a" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="4.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c0c8-5669-4adf-f6b3" name="May Choose Any Runts, Squigs &amp; Know-wots" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="1870-73af-4b91-dcfd" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0c3f-7ce1-3d81-2b42" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="0ad3-3e56-b8a6-1fa9" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f670-475a-de99-ce82" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7554-1c42-10f3-03e3" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6330-f391-1bd2-8d5a" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c7ca-f956-e004-c7db" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7c2c-96cc-6f1c-ae3b" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0d7d-af95-70a5-9184" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="774d-786e-c8e2-2069" name="Gitfinda" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="06a2-8085-b9a3-42c9" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="67fe-b60e-da5c-7abb" name="Warbike" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="bac3-ea2d-4b29-b63e" hidden="false" targetId="7d37a85a-e247-b485-63de-99099729b08f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="5ced-c2f1-38cf-33ec" name="Twin-linked Dakkaguns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6dcd-b790-04dd-7c80" hidden="false" targetId="eaa8e75b-082b-e14a-5e96-b7e729646618" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f0fc-fff7-c561-d451" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="3d20-6ed7-8a8a-109b" hidden="false" targetId="599efb0d-5ca0-a20b-e052-05073a2a2c6c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="be80-9f3e-d9bc-7d99" hidden="false" targetId="c574a454-71f8-c18f-d43f-6af72311ee11" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="54e8-fc84-5e6c-9302" hidden="false" targetId="de54d4cd-6483-9424-6f35-200c3e61a859" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="7897-6ae5-61b4-d053" hidden="false" targetId="216c3599-d3f7-eae7-674a-c9535b05a44c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="3107-d84e-d2ee-e771" hidden="false" targetId="e5f3e3d6-49b9-6d71-1a03-8cd2af8554f8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="2363-2921-8283-c0b6" name="Gifts of Gork and Mork" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="42ab-6fce-99d3-091a" hidden="false" targetId="e8082e4a-deaa-4284-de95-d0b0bb9be10b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="ce4e-e3c9-87c4-37c3" hidden="false" targetId="30cc6165-7121-a4c0-1262-e729b435b68f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="daac-97ea-10cd-8440" hidden="false" targetId="e1874b1b-7ca5-7fe1-5329-a0e073b0c230" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="5433-28aa-e333-cc93" hidden="false" targetId="c0773bfa-69cd-5e61-7d16-35180db73f6e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="12f8-fa92-84f1-fc0a" hidden="false" targetId="94a5b1f7-f37c-222a-66fd-f31515fe8bc0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="a051-8109-fd9d-b174" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="67fe-b60e-da5c-7abb" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="c20f-c562-a9bb-af03" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="3a62-51f2-3d6d-173e" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="8812-fd46-bf19-d223" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -42446,8 +33094,12 @@
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8be-6faf-78e5-8ab8" type="equalTo"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8a1-332b-08b0-133b" type="instanceOf"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab7e-2398-aba4-b734" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8a1-332b-08b0-133b" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c0d-3767-24c8-f20f" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2bb-591a-8f1b-8e5e" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0ec6-d007-89cf-1579" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="465c-1336-3edf-ef25" type="instanceOf"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -42570,375 +33222,6 @@
           <constraints/>
         </entryLink>
         <entryLink id="08fc-bb17-d945-b2c6" hidden="false" targetId="35f3-8e98-ddff-ca9e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="60.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="89d5-f953-1c6d-4322" name="Warboss w/ Mega Armour (WG)" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9bf2-f431-fe03-1622" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="1541-e3d2-7cea-8490" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="20c0-1ebc-6932-62c7" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d213-656c-4f77-6e12" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="fa2a-22c0-a1a4-c64d" hidden="false" targetId="375f7f5f-99b7-cc4c-242d-7382b544b68f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="2+">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="89d5-f953-1c6d-4322" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d3f-240b-8ef4-8550" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </infoLink>
-        <infoLink id="b7fa-8c70-c438-f894" hidden="false" targetId="3c4b757d-bd20-642e-9324-7e9012713139" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="a5d5-22e5-09c0-6e62" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9ab9-6548-6e25-d9c3" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0d3f-240b-8ef4-8550" name="Mega Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="69c6-90b3-ee3f-1327" hidden="false" targetId="6e1e636f-8114-d76a-7ae4-67c4b5822b70" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c0b3-6e91-b659-f055" hidden="false" targetId="e6bc-ea23-502f-5042" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="3348-6aaf-f3a4-a039" hidden="false" targetId="b4c1-e1df-b875-92a6" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="96bb-9b01-18ac-c518" name="May Choose Any Runts, Squigs &amp; Know-wots" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="8081-106d-d17f-e733" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4cc5-7aaf-d39a-35c8" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="fb50-5d42-0848-9980" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e156-d388-7cdc-4dcf" name="Bosspole" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0c62-4886-b4bc-f710" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ff64-edc8-a022-49c1" name="Attack Squig" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="233e-665d-8d5d-303e" hidden="false" targetId="c6b8fd97-d6d7-53b1-d49f-82e6acf62efb" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="11ea-3b44-2d4e-027b" name="Ammo Runt" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7eef-1ee0-2e61-c231" hidden="false" targetId="e0bccf3a-fd54-3b72-fc1c-ad120fe3d00f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="45bf-8c01-5992-9f04" name="Gitfinda" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="f71c-e66c-fdb8-d670" hidden="false" targetId="27f66081-8d1e-025b-3b02-6c5ef7810043" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="24b1-b69f-3339-623b" name="Orkimedes&apos; Kustom Gubbinz" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="1fbc-844d-a2a4-3683" hidden="false" targetId="599efb0d-5ca0-a20b-e052-05073a2a2c6c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="d564-1bfe-e53c-1d7a" hidden="false" targetId="c574a454-71f8-c18f-d43f-6af72311ee11" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="92b1-f9e2-4424-e589" hidden="false" targetId="de54d4cd-6483-9424-6f35-200c3e61a859" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="c974-528a-15c0-c9a5" hidden="false" targetId="216c3599-d3f7-eae7-674a-c9535b05a44c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="7be1-8025-1a1b-6a95" hidden="false" targetId="e5f3e3d6-49b9-6d71-1a03-8cd2af8554f8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1cc0-9b2a-cbb3-7610" name="Gifts of Gork and Mork" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="45fb-cc71-c16c-4c15" hidden="false" targetId="e8082e4a-deaa-4284-de95-d0b0bb9be10b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="1f3a-ebfc-dab0-47c7" hidden="false" targetId="30cc6165-7121-a4c0-1262-e729b435b68f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="f4c7-6675-b5df-5596" hidden="false" targetId="e1874b1b-7ca5-7fe1-5329-a0e073b0c230" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="maxSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="89d5-f953-1c6d-4322" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="33da-9597-8140-32c9" hidden="false" targetId="c0773bfa-69cd-5e61-7d16-35180db73f6e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="faee-5a02-2c84-723b" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="03fc-9fbe-5f04-6132" hidden="false" targetId="35f3-8e98-ddff-ca9e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="4e08-4e72-406a-4e19" hidden="false" targetId="23a5-d259-ea77-c8b6" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="b863-218b-f556-d327" name="New EntryLink" hidden="false" targetId="a9d2-7495-983f-54a6" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -44564,522 +34847,7 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="2482-d9be-1958-b6e3" name="Boyz" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="9efd-e2df-ab50-2962" name="&apos;Eavy Armour for Mob" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="92cf-0920-3f74-2966" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="increment" field="points" value="0.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="afb6-8f6b-a4b1-eb80" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="1520-3786-cce6-f4db">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="2203-e846-1d85-f610" name="Boss Nob" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1ec3-2f1d-d273-e0ed" hidden="false" targetId="47abc561-469a-0e41-00e8-5d9ea56484bc" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="2482-d9be-1958-b6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9efd-e2df-ab50-2962" type="atLeast"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="d0ad-8319-f437-f755" name="Bosspole" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="db25-bd15-0e2e-f961" hidden="false" targetId="0aab2fa5-3bfe-1360-2436-d99e79889668" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="b115-1b66-7a3d-2e65" name="Stikkbombs" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="269b-4ab6-d05d-5198" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="ec69-0721-c176-d5e9" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="6c23-edc1-f53f-c42a" hidden="false" targetId="7104-bd6b-9e73-e763" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="0170-57f7-27e7-f2bd" hidden="false" targetId="8634-ccd3-df89-d499" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="16.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1520-3786-cce6-f4db" name="Boy" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1581-5e46-f922-afa3" hidden="false" targetId="eb659805-d021-ab73-c776-3017ac5c3d26" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="2482-d9be-1958-b6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9efd-e2df-ab50-2962" type="atLeast"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="d762-9993-a155-a3c1" name="Choppa" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="dea9-2a46-46ce-5e15" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8a0a-8b2f-1dfd-ffa7" name="Stikkbombs" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="4957-d7e0-3bae-aa97" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="0485-9a7d-553f-f5df" name="Must Choose 1" hidden="false" collective="false" defaultSelectionEntryId="a9ab-5cb2-cf5a-c5b7">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="a9ab-5cb2-cf5a-c5b7" name="Slugga" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="b844-0cff-dea6-a9ef" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="c115-f08f-9911-1619" name="Shoota" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="32c8-25b1-4fb8-6173" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="1.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="6.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="49e4-d7e0-4dfb-a615" name="Special Weapons" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="maxSelections" value="1.0">
-                      <repeats>
-                        <repeat field="selections" scope="2482-d9be-1958-b6e3" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="afb6-8f6b-a4b1-eb80" repeats="1"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="853c-fa60-9d70-1864" name="Boy w/ Big Shoota" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="0d8b-b911-b9dc-684d" hidden="false" targetId="eb659805-d021-ab73-c776-3017ac5c3d26" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers>
-                            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                              <repeats/>
-                              <conditions>
-                                <condition field="selections" scope="2482-d9be-1958-b6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9efd-e2df-ab50-2962" type="atLeast"/>
-                              </conditions>
-                              <conditionGroups/>
-                            </modifier>
-                          </modifiers>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="1c7a-1cf2-fadf-98b1" name="Big Shoota" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="ed10-0d57-c1cd-5391" hidden="false" targetId="57448769-bae8-59d4-3cee-5c9f2f7a0db1" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="7d3b-4df8-208a-9299" name="Choppa" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="200c-ed75-52a6-30a1" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="338d-a6aa-adbd-e8a2" name="Stikkbombs" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="3530-52b0-e7c3-ee5d" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="dd5f-7ac4-a430-2431" name="Boy w/ Rokkit" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="1275-22d1-a724-9406" hidden="false" targetId="eb659805-d021-ab73-c776-3017ac5c3d26" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers>
-                            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="4+">
-                              <repeats/>
-                              <conditions>
-                                <condition field="selections" scope="2482-d9be-1958-b6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9efd-e2df-ab50-2962" type="atLeast"/>
-                              </conditions>
-                              <conditionGroups/>
-                            </modifier>
-                          </modifiers>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="363e-28f1-73d8-417b" name="Rokkit" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="277a-50c9-a24f-b2c9" hidden="false" targetId="47263fbf-1521-8fd0-b2c8-0dd4a1d3016a" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="2998-d569-dc39-22f9" name="Choppa" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="ea09-c7e9-5d5d-6157" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="c82a-cd29-6662-e1e4" name="Stikkbombs" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks>
-                            <infoLink id="6018-3fa3-46b1-fbb0" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                          </infoLinks>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="0cbc-94de-05eb-f6e5" name="Boss" hidden="false" collective="false" defaultSelectionEntryId="cf00-b8a0-8546-b5f9">
           <profiles/>
@@ -45093,14 +34861,35 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="cf00-b8a0-8546-b5f9" hidden="false" targetId="a051-8109-fd9d-b174" type="selectionEntry">
+            <entryLink id="cf00-b8a0-8546-b5f9" hidden="false" targetId="24ba-2ca9-5ae8-b5ff" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="84cb-3750-a11f-636c" hidden="false" targetId="89d5-f953-1c6d-4322" type="selectionEntry">
+            <entryLink id="84cb-3750-a11f-636c" hidden="false" targetId="6cfa-d1ae-de1d-24d0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="573a-37bc-6bff-ac87" name="Boyz" hidden="false" collective="false" defaultSelectionEntryId="d13f-e0c9-d859-7c2f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d735-4b09-b639-4bb6" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3718-15c4-fcc7-37a4" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d13f-e0c9-d859-7c2f" name="New EntryLink" hidden="false" targetId="c55d-5a8f-437a-373a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -46260,6 +36049,453 @@ Roles only while operating as Zooming Flyers. If they exit the board into Ongoin
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="617b-779d-5627-57b7" name="Boss Zagstruk, Da Boss" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2df6-5931-7252-008c" hidden="false" targetId="2b4f220f-06c3-dd73-c9f2-a9a0ff17860e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3d8d-95bb-c07a-7730" hidden="false" targetId="beccfd4d-727c-b85e-2bc7-82d4855fc906" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e700-f17f-01db-2c29" hidden="false" targetId="58758be2-d4f4-2ae1-5b2d-e9c4128aec04" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6af7-5ff1-8fda-8846" hidden="false" targetId="b6da-cce3-2346-9c27" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d0c5-09c0-445d-9842" hidden="false" targetId="ef3b-09c6-4024-cd37" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bac8-5e43-7aa4-9bec" hidden="false" targetId="b2bcc5eb-8b54-d781-9bc4-d98238313546" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0b2b-879b-bb35-9165" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfea-b243-9fd8-4edf" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fef2-afb4-3474-4e46" name="Cybork Body" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="cd7f-37db-4555-0ef9" hidden="false" targetId="ac2aad6c-f419-14d9-394c-6a62db6597cd" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="20bb-4921-855f-5022" hidden="false" targetId="257e406b-e006-275d-b110-5675b4dcbe8b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd2b-3289-7d07-62ea" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f07-b19f-a7bf-4484" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="538a-3655-cf7a-fdb1" name="Da Vulcha&apos;s Klaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b294-fc4b-7eca-2d78" hidden="false" targetId="9636d31c-6837-f767-9187-aefcc0470727" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d30-db08-989a-786d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a09b-c82e-ba5e-7a51" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bafd-4f78-d9a3-8661" name="Stikkbombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1ecc-36e6-89d2-0891" hidden="false" targetId="10ac3ee4-c530-de10-eed0-253b125b7cf0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f8a6-11ea-e180-584a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f113-4f35-11a7-b9a2" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b4a7-e9d5-531f-ad52" name="Slugga" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c976-223e-e1cc-6752" hidden="false" targetId="b5161c22-8241-12a3-4fb0-e8a08b7eea87" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e517-be95-bf75-c152" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eaac-3dbb-fc4a-8660" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c10e-0dd3-3f40-e121" name="Rokkit Pack" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ce29-507c-5681-b389" hidden="false" targetId="00b19c1b-2e18-0f04-52df-aeb27c8d139a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a86-93ad-36ba-ef26" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b6c7-69ed-2158-bcc6" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="40fa-2dec-b3c7-8b6f" name="Choppa" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6950-e87a-8f01-75c6" hidden="false" targetId="b5a15a10-378a-f59e-80a7-090b5c95a19d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="691e-22cb-a56b-e3f5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c7b-fe0f-3f2f-cbd5" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f27c-bb1f-816c-6ae4" name="&apos;Eavy Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="923d-ad0b-f4e6-1aad" hidden="false" targetId="bd8e7c2b-6aee-35b7-6f19-41a4a09c92f1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="07d6-8ee9-cb84-d202" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f467-435e-bb46-b8e2" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="037e-fa97-578e-b386" hidden="false" targetId="a9d2-7495-983f-54a6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7eff-a4b6-28ef-0ff5" hidden="false" targetId="f3aee269-2f69-f57e-eaea-6a91ac502357" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="28a6-3572-7007-29e6" name="Killa Kans" book="Codex: Orks" page="0" hidden="false" collective="false" categoryEntryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="abed-7ac0-5dd7-ca0c" hidden="false" targetId="5cd704ba-04d7-96c1-17fe-be4fb093117c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="150e-4969-eb33-a33f" value="0.0">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4a7bc38-f85c-0552-d50c-cf3640222184" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="150e-4969-eb33-a33f" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2e80-5975-9fed-fa59" name="Killa Kan" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0475-c058-35c5-f32f" hidden="false" targetId="c798f715-ec69-02f8-aaf3-ff7bc3171cf2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61ac-3180-ce67-5265" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04fa-bae3-33e2-f9a5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0536-59c4-b6cd-6667" name="Kan Klaw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8f5f-494a-32e5-7176" hidden="false" targetId="07f43816-45a2-2e82-d805-1c603ef2c5b5" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3aaa-c212-3222-0a94" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f009-1b53-c106-15f2" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7309-e28f-e384-616c" name="May Choose Any" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="1869-c946-72ad-ab10" name="Grot Riggers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="085d-e81f-9e7a-4ac7" hidden="false" targetId="74f3260d-4895-0bd7-9247-9e0c7fc8b270" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="76e8-2fc1-1eec-72cd" hidden="false" targetId="8de3-9e93-da02-b9dd" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b062-4826-f256-6ff0" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6395-2326-26a4-77d1" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="a9ca-2525-c682-9a7d" hidden="false" targetId="f8b7d6ab-57de-4759-01b3-d37c7a935c83" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="683c-b2fa-6c58-5a89" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="81b1-d4ff-e9b5-5caa" hidden="false" targetId="03be-c490-b054-b185" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a4f-93b3-5796-1eec" name="&quot;Painmob&quot;" book="Start Collecting! Orks" hidden="false" collective="false" categoryEntryId="28b94f51-e66b-4096-aa59-0c9df620a77d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e244-2eee-2a33-2a3f" hidden="false" targetId="d12a-2728-5e61-78d4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c620-9c06-3361-b327" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="738e-1345-b2c0-b5d2" hidden="false" targetId="ba28-9d0a-4872-eaf9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="098e-3773-5b8c-de40" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c464-b327-7c6e-cc40" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="40d8-6412-5d17-f451" hidden="false" targetId="c55d-5a8f-437a-373a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e47-526f-f46e-6386" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b974-fd99-f818-aef2" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0c39-d857-6aab-991e" name="New EntryLink" hidden="false" targetId="af54b56d-02bf-9cc3-16da-99944a168e89" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c4f-f4c4-e244-8146" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a47-3d42-f260-a735" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d107-933a-4ec7-8294" name="New EntryLink" hidden="false" targetId="632cf00b-e88d-4c00-d57e-8965f2ad805b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb9b-10d9-b619-30d2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f87-b415-526e-0520" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -47783,6 +38019,146 @@ Roles only while operating as Zooming Flyers. If they exit the board into Ongoin
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="687e-7590-5136-45a8" name="Meganob Weapons" hidden="false" collective="false" defaultSelectionEntryId="750b-a55d-35e0-51ae">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a79-6e19-81b3-3a7f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76a7-3651-b9f3-efa3" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="df5e-db7c-e0f1-e3ce" name="Pair of Killsaws" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f380-c83f-d86a-0edb" hidden="false" targetId="0e4f3e53-4dae-120f-149e-8cc799313b51" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7945-4051-0bad-29a7" name="PK &amp; Kombi-Rokkit" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="34c6-f096-af33-559c" name="New InfoLink" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="09f1-4513-9167-08c6" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="babb-af7d-2db3-aada" hidden="false" targetId="3a5e5b32-bf2f-ad9b-4d15-4070f6ccf6bf" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="afaa-4527-5614-03b4" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="718b-9548-1863-acd4" name="PK &amp; Kombi-Skorcha" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="43e8-31a2-63b8-e75e" name="New InfoLink" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="12a3-a3ba-1ff1-6a31" hidden="false" targetId="b9acf151-1b3a-6d61-fc07-074c4ed705f2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="82ac-6b22-5ec8-7cfe" hidden="false" targetId="2eabaf9f-1f6d-260f-981d-18187b1a3a31" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="11cf-94fa-e9e6-273f" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="750b-a55d-35e0-51ae" name="PK &amp; TL-Shoota" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="bb1f-ffd0-15a8-7fbd" name="New InfoLink" hidden="false" targetId="0a9ae162-febf-d5b0-e8ca-6c7256d016c6" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9332-074a-f659-99ac" name="New InfoLink" hidden="false" targetId="99be63a3-ddc8-c52f-272b-fbca86291f9d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a912-90ae-df8a-10c1" name="New InfoLink" hidden="false" targetId="3002-de38-7230-fbc6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>


### PR DESCRIPTION
I fixed Constraints on a number of formations.  Closes #2930    Closes
#2929

I also removed many duplicate entries, and moved several entries to
shared entries to avoid future duplicates.

Finally, I changed the way meganobz selected wargear.  The old way was
annoying and cumbersome.