### PR TITLE
IK v2014

### DIFF
--- a/Imperial Knights - Codex (2015).cat
+++ b/Imperial Knights - Codex (2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6940-50fe-5175-21fa" name="Imperial Knights: Codex (2015)" book="Imperial Knights: Codex" revision="2013" battleScribeVersion="2.00" authorName="Hisop" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="2000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6940-50fe-5175-21fa" name="Imperial Knights: Codex (2015)" book="Imperial Knights: Codex" revision="2014" battleScribeVersion="2.00" authorName="Hisop" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="2000" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -468,9 +468,9 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry id="f16a-b7c2-023d-bd05" name="Apocalypse Missle Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                    <selectionEntry id="f16a-b7c2-023d-bd05" name="Apocalypse Missile Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                       <profiles>
-                        <profile id="5b76-62df-117c-bd9d" name="Apocalypse Missle Launcher" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
+                        <profile id="5b76-62df-117c-bd9d" name="Apocalypse Missile Launcher" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -592,9 +592,9 @@
                         <cost name="pts" costTypeId="points" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="1264-c81e-b353-da58" name="Vortex Missle" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                    <selectionEntry id="1264-c81e-b353-da58" name="Vortex Missile" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                       <profiles>
-                        <profile id="214f-f4f3-f8f1-f054" name="Vortex Missle" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
+                        <profile id="214f-f4f3-f8f1-f054" name="Vortex Missile" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -8581,35 +8581,28 @@ Catastrophic Damage table.</description>
             <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee, Colossal, Hurl"/>
           </characteristics>
         </profile>
-        <profile id="df82-7a22-e7a1-5c85" name="Hurl" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="12&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" value="*"/>
-            <characteristic name="AP" characteristicTypeId="6abee736-f8d3-498e-97ac-a5c68445609f" value="-"/>
-            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 1, Large Blast, The Bigger They Are..."/>
-          </characteristics>
-        </profile>
       </profiles>
-      <rules>
-        <rule id="c313-a4e6-513b-cee8" name="The Bigger They Are..." hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="59b7-7349-2834-a368" name="New InfoLink" hidden="false" targetId="8571-f0e5-26df-749c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>The Strength of this attack is always equal to the Toughness value of the Monstrous Creature, or half the front Armour Value of the vehicle being hurled (rounding fractions up)</description>
-        </rule>
-        <rule id="8094-0381-bd7e-c8e7" name="Hurl" hidden="false">
+        </infoLink>
+        <infoLink id="4c41-f4f8-b943-dc23" name="New InfoLink" hidden="false" targetId="bf81-5180-7825-5e3e" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+        <infoLink id="71e3-947b-1a3c-5c0b" name="New InfoLink" hidden="false" targetId="aa1d-36c5-2e13-0ee1" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3793-57a4-3376-fffc" type="max"/>
@@ -8650,7 +8643,7 @@ Catastrophic Damage table.</description>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8886-4d7b-9e20-bb33" name="Ironstorm Missle Pod" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="8886-4d7b-9e20-bb33" name="Ironstorm Missile Pod" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -10038,7 +10031,7 @@ In addition, any attacks or special abilities that permanently lower the Armour 
         <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Ordnance 1, Large Blast"/>
       </characteristics>
     </profile>
-    <profile id="5f69-ab5b-ac3d-aebe" name="Ironstorm Missle Pod" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
+    <profile id="5f69-ab5b-ac3d-aebe" name="Ironstorm Missile Pod" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48">
       <profiles/>
       <rules/>
       <infoLinks/>


### PR DESCRIPTION
Fixed Missle/Missile typo.
Thunderstrike Gauntlet now links to shared profile Hurl and shared rules
Hurl and The Bigger They Are... instead of redefining them.
Fixes #3650.