### PR TITLE
Dark Angels Fixes

### DIFF
--- a/Dark Angels.cat
+++ b/Dark Angels.cat
@@ -14214,7 +14214,7 @@
             <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
             <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
             <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="6"/>
-            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="69"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="9"/>
             <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="3"/>
             <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
@@ -14939,14 +14939,15 @@
         <modifier type="set" field="e356-c769-5920-6e14" value="19">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="5db6-09fd-b607-e027" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a8ed-5a9f-e477-4910" type="atLeast"/>
+            <condition field="selections" scope="5db6-09fd-b607-e027" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
           </conditions>
           <conditionGroups/>
         </modifier>
         <modifier type="set" field="e356-c769-5920-6e14" value="12">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="5db6-09fd-b607-e027" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a8ed-5a9f-e477-4910" type="atLeast"/>
+            <condition field="selections" scope="5db6-09fd-b607-e027" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+            <condition field="selections" scope="5db6-09fd-b607-e027" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atMost"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -15004,7 +15005,7 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="a8ed-5a9f-e477-4910" name="Ravenwing Black Knight" hidden="false" collective="true" type="model">
+        <selectionEntry id="a8ed-5a9f-e477-4910" name="Ravenwing Black Knight" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="bbfa-a94b-102d-ad3d" name="Ravenwing Black Knight" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
               <profiles/>
@@ -15288,10 +15289,10 @@
           </entryLinks>
           <costs>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="50.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4724-0b43-76a6-4456" name="Ravenwing Black Knight (Grenade Launcher)" hidden="false" collective="true" type="model">
+        <selectionEntry id="4724-0b43-76a6-4456" name="Ravenwing Black Knight (Grenade Launcher)" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="aba1-e8eb-5f4c-26d2" name="Ravenwing Black Knight" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
               <profiles/>


### PR DESCRIPTION
Dark Shroud W=69 to W=6
removed Black Knights collective tag which caused problems with multiple units of Black Knights
added 50 pts to Black Knight Huntsman
Fixes increasing PL of black knights when 7 or more are added to a unit
Fixed Belial thunder hammer and storm shield points value (should be 0). Within the "Thunder and Storm shield" shared selection, I had to give this selection pts and set the individual weapon pts to 0, so that belial's set pts to 0 would work.

