### PR TITLE
Fixed typos, Tyranids: exocrine, spore mine launcher, mucolid spores.

### DIFF
--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -1041,7 +1041,7 @@
         </profile>
       </profiles>
       <rules>
-        <rule id="747a-05a9-a399-6e59" name="Sybiotic Targeting" book="Index: Xenos 2" page="107" hidden="false">
+        <rule id="747a-05a9-a399-6e59" name="Symbiotic Targeting" book="Index: Xenos 2" page="107" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3137,7 +3137,7 @@ Each time a spore mine launcher missed its target, set up a single Spore Mine mo
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>A Mucolid Spore exploded if it is within 3&quot; of any enemy units at the end of any Charge phase. Each time a Mucolid Spore explodes, roll a D6; on a 1 it fails to inflict an harm, on a 2-5 it inflicts D3 mortal wounds on the nearest enemy unit, and on a 6 it inflicts D6 mortal wounds on that unit. The Mucolid Spore is then destroyed.</description>
+          <description>A Mucolid Spore explodes if it is within 3&quot; of any enemy units at the end of any Charge phase. Each time a Mucolid Spore explodes, roll a D6; on a 1 it fails to inflict an harm, on a 2-5 it inflicts D3 mortal wounds on the nearest enemy unit, and on a 6 it inflicts D6 mortal wounds on that unit. The Mucolid Spore is then destroyed.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -8168,7 +8168,7 @@ Any models that are inside the Tyrannocyte must immediately disembark in the sam
           <modifiers/>
           <description>Each time a spore mine launcher hits the target, roll a D6 to find out how much damage is inflicted on the target; on a 1 the Spore Mine fails to inflict any harm, on a 2-5 it inflicts 1 mortal wound, and on a 6 it inflicts D3 mortal wounds.
 
-Each time a spore mine launcher missed its target, set up a single Spore Mine model anywhere within 6&quot; of the target and more than 3&quot; from any enemy model (if the Spore Mine cannot be placed it is destroyed). This then follows the rules for a Spore Mine (pg 103) that is part of your army, but it cannot move or charge during the turn it was set up.</description>
+Each time a spore mine launcher misses its target, set up a single Spore Mine model anywhere within 6&quot; of the target and more than 3&quot; from any enemy model (if the Spore Mine cannot be placed it is destroyed). This then follows the rules for a Spore Mine (pg 103) that is part of your army, but it cannot move or charge during the turn it was set up.</description>
         </rule>
       </rules>
       <infoLinks>


### PR DESCRIPTION
Tyranids:

Exocrine: "Symbiotic" rather than Sybiotic Targeting.

Mucolid Spores: "A Mucolid spore explodes" not "exploded".

Biovores: "Each time a spore mine laucher misses" not "missed".
